### PR TITLE
[Feature] 지도 뷰 카테고리 버튼 구현, 탭바 구현

### DIFF
--- a/FlatBread/App/ContentView.swift
+++ b/FlatBread/App/ContentView.swift
@@ -8,14 +8,42 @@
 import SwiftUI
 
 struct ContentView: View {
+    
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        // tabItem modifier는 deprecated되었으나,
+        // 그 대체제인 Tab은 iOS 18.0 이상부터 사용 가능하므로
+        // tabItem modifier를 사용하였음.
+        TabView {
+            Color(.green)
+                .ignoresSafeArea()
+                .tabItem {
+                    Label("홈", systemImage: "house")
+                }
+            
+            Color(.blue)
+                .ignoresSafeArea()
+                .tabItem {
+                    Label("숏폼", systemImage: "play.rectangle")
+                }
+            
+            MainMapView()
+                .tabItem {
+                    Label("지도", systemImage: "map")
+                }
+            
+            Color(.yellow)
+                .ignoresSafeArea()
+                .tabItem {
+                    Label("지도", systemImage: "checkmark.rectangle.stack")
+                }
+            
+            Color(.orange)
+                .ignoresSafeArea()
+                .tabItem {
+                    Label("지도", systemImage: "person")
+                }
         }
-        .padding()
+        .tint(.black)
     }
 }
 

--- a/FlatBread/App/ContentView.swift
+++ b/FlatBread/App/ContentView.swift
@@ -9,6 +9,14 @@ import SwiftUI
 
 struct ContentView: View {
     
+    init() {
+        let tabBarAppearance = UITabBarAppearance()
+        tabBarAppearance.configureWithDefaultBackground()
+        
+        UITabBar.appearance().standardAppearance = tabBarAppearance
+        UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
+    }
+    
     var body: some View {
         // tabItem modifier는 deprecated되었으나,
         // 그 대체제인 Tab은 iOS 18.0 이상부터 사용 가능하므로

--- a/FlatBread/Features/Map/Model/MainMapCategoryUIModel.swift
+++ b/FlatBread/Features/Map/Model/MainMapCategoryUIModel.swift
@@ -1,0 +1,13 @@
+//
+//  MainMapCategoryUIModel.swift
+//  FlatBread
+//
+//  Created by 김민성 on 11/11/25.
+//
+
+struct MainMapCategoryUIModel: Hashable {
+    let name: String
+    /// system image name
+    let image: String
+    var isSelected: Bool = true
+}

--- a/FlatBread/Features/Map/Presentation/Components/MainMapCategoryButton.swift
+++ b/FlatBread/Features/Map/Presentation/Components/MainMapCategoryButton.swift
@@ -1,0 +1,44 @@
+//
+//  MainMapCategoryButton.swift
+//  FlatBread
+//
+//  Created by 김민성 on 11/11/25.
+//
+
+import SwiftUI
+
+struct MainMapCategoryButton: View {
+    
+    @Binding var category: MainMapCategoryUIModel
+    private let verticalInset: CGFloat = 10
+    private let horizontalInset: CGFloat = 16
+    private let clipShape = RoundedRectangle(cornerRadius: 30)
+    
+    var body: some View {
+        Button {
+            category.isSelected.toggle()
+        } label: {
+            
+            HStack {
+                Image(systemName: category.image)
+                Text(category.name)
+            }
+            .padding(
+                .init(top: verticalInset,
+                      leading: horizontalInset,
+                      bottom: verticalInset,
+                      trailing: horizontalInset)
+            )
+            .background(.yellow.opacity(category.isSelected ? 1.0 : 0.6))
+            .clipShape(clipShape)
+            .overlay { clipShape.stroke(.orange, lineWidth: category.isSelected ? 3 : 0) }
+        }
+        .buttonStyle(.plain)
+    }
+    
+}
+
+#Preview {
+    @Previewable @State var category = MainMapCategoryUIModel(name: "운동", image: "figure.run")
+    MainMapCategoryButton(category: $category)
+}

--- a/FlatBread/Features/Map/Presentation/MainMapView.swift
+++ b/FlatBread/Features/Map/Presentation/MainMapView.swift
@@ -13,6 +13,14 @@ struct MainMapView: View {
     
     @State private var coordinate: NMGLatLng
     @State private var searchText: String = ""
+    @State private var categories: [MainMapCategoryUIModel] = [
+        .init(name: "운동", image: "figure.run"),
+        .init(name: "공부", image: "pencil"),
+        .init(name: "여행", image: "map"),
+        .init(name: "코딩", image: "swift"),
+        .init(name: "bakery", image: "birthday.cake"),
+    ]
+    private var selectedCategories: Set<MainMapCategoryUIModel> = []
     @State private var moims: [Moim] = []
     @State private var markers: [MoimMarker] = []
     @State private var focusingPlaceID: String? = nil
@@ -29,6 +37,17 @@ struct MainMapView: View {
                 
                 VStack {
                     MainMapSearchBar(searchText: $searchText)
+                    ScrollView(.horizontal) {
+                        HStack {
+                            ForEach($categories, id: \.name) { category in
+                                MainMapCategoryButton(category: category)
+                            }
+                        }
+                        .padding(.vertical, 1.5)
+                        .padding(.horizontal)
+                    }
+                    .scrollIndicators(.hidden)
+                    
                     Spacer()
                 }
                 .background(


### PR DESCRIPTION
## 개요
<!-- 구현한 기능을 간단히 설명해주세요 -->
- 지도 화면에 카테고리 버튼을 추가했습니다.
- 탭바의 기본 구성을 만들었습니다.

## 관련 이슈
Resolves #17 

## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- 카테고리 버튼은 중복 선택이 가능하며 선택 시 테두리가 보이도록 했습니다.
- 카테고리 값은 임시로 만든 것이므로, 추후 카테고리 종류가 확정되면 적용 예정입니다.
- 탭바의 기본 틀을 구성하였습니다.
  - 지도 탭을 제외한 다른 탭은 더미 뷰로 구성하였고, 추후 추가되는 뷰는 갈아끼우면 될 것 같습니다.

## 체크리스트
- [x] 빌드 성공
- [ ] 테스트 완료
- [ ] 에러 처리 완료

|iOS 18 이전|iOS 18 이후|지도 뷰|
|:---:|:---:|:---:|
|  <img width="200" alt="스크린샷 2025-11-14 오후 11 08 55" src="https://github.com/user-attachments/assets/4bc4c0ef-1606-4b10-ad7b-de4c07e61dc9" /> |  <img width="200" alt="스크린샷 2025-11-14 오후 11 10 01" src="https://github.com/user-attachments/assets/8e1ba886-d758-4540-a9a2-18857db3e85e" />  |  <img width="200" alt="스크린샷 2025-11-14 오후 11 10 21" src="https://github.com/user-attachments/assets/54afc4ba-d6f5-49fe-8ea2-e209fe9e6176" /> |

