### PR TITLE
[feat/createMoimView] 모임 생성 뷰 구현

### DIFF
--- a/FlatBread/Features/CreateMoim/Presentation/Components/ChipButton.swift
+++ b/FlatBread/Features/CreateMoim/Presentation/Components/ChipButton.swift
@@ -1,0 +1,46 @@
+//
+//  ChipButton.swift
+//  FlatBread
+//
+//  Created by andev on 11/14/25.
+//
+
+import SwiftUI
+
+struct ChipButton: View {
+    let title: String
+    let isSelected: Bool
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 14, weight: .semibold))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(isSelected ? Color.black : Color(.systemGray6))
+                )
+                .overlay(
+                    Capsule(style: .continuous)
+                        .stroke(isSelected ? Color.black : Color(.systemGray4), lineWidth: 1)
+                )
+                .foregroundStyle(isSelected ? .white : .primary)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview() {
+    ScrollView(.horizontal, showsIndicators: false) {
+        HStack(spacing: 8) {
+            ChipButton(title: "운동", isSelected: false, action: {})
+            ChipButton(title: "동네친구", isSelected: true, action: {})
+            ChipButton(title: "스터디", isSelected: false, action: {})
+            ChipButton(title: "게임", isSelected: false, action: {})
+        }
+        .padding(16)
+    }
+    .background(Color(.systemBackground))
+}

--- a/FlatBread/Features/CreateMoim/Presentation/Components/MapPickerView.swift
+++ b/FlatBread/Features/CreateMoim/Presentation/Components/MapPickerView.swift
@@ -1,0 +1,62 @@
+//
+//  MapPickerView.swift
+//  FlatBread
+//
+//  Created by andev on 11/14/25.
+//
+
+import SwiftUI
+import MapKit
+import CoreLocation
+
+struct MapPickerView: View {
+    @Binding var coordinate: CLLocationCoordinate2D
+    
+    @State private var camera: MapCameraPosition
+    
+    init(coordinate: Binding<CLLocationCoordinate2D>) {
+        _coordinate = coordinate
+        _camera = State(initialValue: .region(
+            MKCoordinateRegion(
+                center: coordinate.wrappedValue,
+                span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+            )
+        ))
+    }
+    
+    var body: some View {
+        ZStack {
+            Map(position: $camera, interactionModes: [.all])
+                .ignoresSafeArea(edges: .horizontal)
+                .onMapCameraChange(frequency: .continuous) { ctx in
+                    // 중심 좌표를 선택값으로 사용
+                    coordinate = ctx.region.center
+                }
+            
+            // 중앙 고정 핀
+            Image(systemName: "mappin.and.ellipse")
+                .font(.system(size: 28, weight: .bold))
+                .foregroundStyle(.red)
+                .shadow(radius: 4)
+            
+            // 좌표 표시 바
+            VStack {
+                Spacer()
+                HStack {
+                    Text(String(format: "위도 %.5f, 경도 %.5f",
+                                coordinate.latitude, coordinate.longitude))
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .padding(.bottom, 8)
+            }
+            .allowsHitTesting(false)
+        }
+        .frame(height: 220)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}

--- a/FlatBread/Features/CreateMoim/Presentation/Model/MoimCategory.swift
+++ b/FlatBread/Features/CreateMoim/Presentation/Model/MoimCategory.swift
@@ -1,0 +1,23 @@
+//
+//  MoimCategory.swift
+//  FlatBread
+//
+//  Created by andev on 11/14/25.
+//
+
+import Foundation
+
+struct MoimCategory: Identifiable, Hashable {
+    let id = UUID()
+    let name: String
+}
+
+// 더미 모델
+extension Array where Element == MoimCategory {
+    static var dummy10: [MoimCategory] {
+        [
+            "운동", "동네친구", "스터디", "게임", "음악",
+            "독서", "사진", "러닝", "등산", "요리"
+        ].map { MoimCategory(name: $0) }
+    }
+}

--- a/FlatBread/Features/CreateMoim/Presentation/View/CreateMoimView.swift
+++ b/FlatBread/Features/CreateMoim/Presentation/View/CreateMoimView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import MapKit
 import CoreLocation
+import PhotosUI
 
 struct CreateMoimView: View {
     
@@ -16,9 +17,11 @@ struct CreateMoimView: View {
     // 바인딩용 좌표
     @State private var selectedCoord = CLLocationCoordinate2D(latitude: 37.5665, longitude: 126.9780)
     
+    // 대표 사진 선택용
+    @State private var pickerItem: PhotosPickerItem? = nil
+    
     var body: some View {
         VStack(spacing: 0) {
-            // 상단 타이틀
             HStack {
                 Text("어떤 모임을 만들까요?")
                     .font(.system(size: 28, weight: .bold))
@@ -30,11 +33,82 @@ struct CreateMoimView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
                     
+                    // MARK: - 모임 대표 사진
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("모임 대표 사진")
+                            .font(.headline)
+                        
+                        ZStack {
+                            // 프리뷰
+                            if let data = vm.selectedImageData,
+                               let uiImage = UIImage(data: data) {
+                                Image(uiImage: uiImage)
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(maxWidth: .infinity)
+                                    .frame(height: 180)
+                                    .clipped()
+                                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            } else {
+                                // 플레이스홀더
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .stroke(style: StrokeStyle(lineWidth: 1, dash: [6]))
+                                    .foregroundStyle(Color(.systemGray4))
+                                    .frame(height: 180)
+                                    .overlay {
+                                        VStack(spacing: 8) {
+                                            Image(systemName: "photo.on.rectangle.angled")
+                                                .font(.system(size: 26, weight: .semibold))
+                                            Text("대표 이미지를 선택해 주세요")
+                                                .font(.subheadline)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                    }
+                            }
+                        }
+                        
+                        // 선택 버튼
+                        PhotosPicker(selection: $pickerItem,
+                                     matching: .images,
+                                     photoLibrary: .shared()) {
+                            Label("사진 선택", systemImage: "photo.fill.on.rectangle.fill")
+                                .font(.system(size: 15, weight: .semibold))
+                                .padding(.horizontal, 14)
+                                .padding(.vertical, 10)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                        .fill(Color(.systemGray6))
+                                )
+                        }
+                                     .onChange(of: pickerItem) { _, newItem in
+                                         guard let item = newItem else {
+                                             vm.setSelectedImage(data: nil)
+                                             return
+                                         }
+                                         Task {
+                                             // Data로 로드 (HEIC/JPG 등 바이너리)
+                                             if let data = try? await item.loadTransferable(type: Data.self) {
+                                                 await MainActor.run { vm.setSelectedImage(data: data) }
+                                             }
+                                         }
+                                     }
+                        
+                        if vm.isUploading {
+                            HStack(spacing: 8) {
+                                ProgressView()
+                                Text("이미지 업로드 중…")
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    
                     // MARK: - 모임명
                     VStack(alignment: .leading, spacing: 8) {
                         Text("모임명")
                             .font(.headline)
-
+                        
                         VStack(alignment: .leading, spacing: 4) {
                             TextField("모임명이 짧을수록 이해하기 쉬워요.", text: vm.titleBinding)
                                 .textInputAutocapitalization(.never)
@@ -66,9 +140,7 @@ struct CreateMoimView: View {
                                     ChipButton(
                                         title: cat.name,
                                         isSelected: vm.selectedCategory == cat
-                                    ) {
-                                        vm.selectCategory(cat)
-                                    }
+                                    ) { vm.selectCategory(cat) }
                                 }
                             }
                             .padding(.vertical, 4)
@@ -81,9 +153,7 @@ struct CreateMoimView: View {
                         Text("활동 지역")
                             .font(.headline)
                         MapPickerView(coordinate: Binding(
-                            get: {
-                                CLLocationCoordinate2D(latitude: vm.dto.latitude, longitude: vm.dto.longitude)
-                            },
+                            get: { CLLocationCoordinate2D(latitude: vm.dto.latitude, longitude: vm.dto.longitude) },
                             set: { vm.updateCoordinate($0) }
                         ))
                     }
@@ -122,7 +192,7 @@ struct CreateMoimView: View {
                     }
                     .padding(.horizontal, 16)
                     
-                    // MARK: - 가격 설정
+                    // MARK: - 입장료 설정
                     VStack(alignment: .leading, spacing: 10) {
                         Text("입장료 설정")
                             .font(.headline)
@@ -139,7 +209,7 @@ struct CreateMoimView: View {
                                     .font(.system(size: 18, weight: .semibold))
                                 TextField("금액 입력 (원)", text: $vm.priceText)
                                     .keyboardType(.numberPad)
-                                    .onChange(of: vm.priceText) { oldValue, newValue in
+                                    .onChange(of: vm.priceText) { _, _ in
                                         vm.commitPriceFromText()
                                     }
                             }
@@ -159,8 +229,7 @@ struct CreateMoimView: View {
             
             // 하단 제출 버튼
             Button {
-                if vm.isFree { vm.dto.price = 0 } else { vm.commitPriceFromText() }
-                vm.createTapped()      // 현재는 print로 확인
+                Task { await vm.submit() }   // 업로드 → URL 반영 → 생성
             } label: {
                 Text("모임 만들기")
                     .font(.system(size: 17, weight: .semibold))
@@ -172,10 +241,23 @@ struct CreateMoimView: View {
                     .padding(.horizontal, 16)
                     .padding(.vertical, 8)
             }
-            .disabled(!vm.canSubmit)
+            .disabled(!vm.canSubmit || vm.isUploading)
             .background(Color(.systemBackground))
         }
         .background(Color(.systemBackground))
+        .alert(
+            "이미지 업로드 오류",
+            isPresented: Binding(
+                get: { vm.uploadErrorMessage != nil },
+                set: { newValue in if !newValue { vm.uploadErrorMessage = nil } }
+            )
+        ) {
+            Button("확인", role: .cancel) {
+                vm.uploadErrorMessage = nil
+            }
+        } message: {
+            Text(vm.uploadErrorMessage ?? "이미지 크기가 10MB를 초과합니다. 이미지 크기를 줄인 후 다시 시도해 주세요.")
+        }
     }
 }
 

--- a/FlatBread/Features/CreateMoim/Presentation/View/CreateMoimView.swift
+++ b/FlatBread/Features/CreateMoim/Presentation/View/CreateMoimView.swift
@@ -1,0 +1,184 @@
+//
+//  CreateMoimView.swift
+//  FlatBread
+//
+//  Created by andev on 11/14/25.
+//
+
+import SwiftUI
+import MapKit
+import CoreLocation
+
+struct CreateMoimView: View {
+    
+    @StateObject private var vm = CreateMoimViewModel()
+    
+    // 바인딩용 좌표
+    @State private var selectedCoord = CLLocationCoordinate2D(latitude: 37.5665, longitude: 126.9780)
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            // 상단 타이틀
+            HStack {
+                Text("어떤 모임을 만들까요?")
+                    .font(.system(size: 28, weight: .bold))
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+            
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    
+                    // MARK: - 모임명
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("모임명")
+                            .font(.headline)
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            TextField("모임명이 짧을수록 이해하기 쉬워요.", text: vm.titleBinding)
+                                .textInputAutocapitalization(.never)
+                                .disableAutocorrection(true)
+                                .padding(14)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                        .stroke(Color(.systemGray4), lineWidth: 1)
+                                )
+                            
+                            HStack {
+                                Spacer()
+                                Text("\(vm.dto.title?.count ?? 0)/\(vm.titleLimit)")
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    
+                    // MARK: - 카테고리
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("카테고리")
+                            .font(.headline)
+                        
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 8) {
+                                ForEach(vm.categories) { cat in
+                                    ChipButton(
+                                        title: cat.name,
+                                        isSelected: vm.selectedCategory == cat
+                                    ) {
+                                        vm.selectCategory(cat)
+                                    }
+                                }
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    
+                    // MARK: - 활동 지역
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("활동 지역")
+                            .font(.headline)
+                        MapPickerView(coordinate: Binding(
+                            get: {
+                                CLLocationCoordinate2D(latitude: vm.dto.latitude, longitude: vm.dto.longitude)
+                            },
+                            set: { vm.updateCoordinate($0) }
+                        ))
+                    }
+                    .padding(.horizontal, 16)
+                    
+                    // MARK: - 모임 소개
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("모임 소개")
+                            .font(.headline)
+                        
+                        ZStack(alignment: .topLeading) {
+                            TextEditor(text: vm.contentBinding)
+                                .frame(minHeight: 160, maxHeight: .infinity)
+                                .padding(10)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                        .stroke(Color(.systemGray4), lineWidth: 1)
+                                )
+                            
+                            if (vm.dto.content ?? "").isEmpty {
+                                Text("활동 중심으로 모임을 소개해주세요. 소개를 잘 작성한 모임은 2배 많은 이웃이 가입해요.")
+                                    .foregroundStyle(.secondary)
+                                    .font(.body)
+                                    .padding(.horizontal, 14)
+                                    .padding(.vertical, 14)
+                                    .allowsHitTesting(false)
+                            }
+                        }
+                        
+                        HStack {
+                            Spacer()
+                            Text("\(vm.dto.content?.count ?? 0)/\(vm.contentLimit)")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    
+                    // MARK: - 가격 설정
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("입장료 설정")
+                            .font(.headline)
+                        
+                        Toggle("무료", isOn: Binding(
+                            get: { vm.isFree },
+                            set: { vm.toggleFree($0) }
+                        ))
+                        .toggleStyle(.switch)
+                        
+                        if !vm.isFree {
+                            HStack(spacing: 8) {
+                                Text("₩")
+                                    .font(.system(size: 18, weight: .semibold))
+                                TextField("금액 입력 (원)", text: $vm.priceText)
+                                    .keyboardType(.numberPad)
+                                    .onChange(of: vm.priceText) { oldValue, newValue in
+                                        vm.commitPriceFromText()
+                                    }
+                            }
+                            .padding(12)
+                            .background(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .stroke(Color(.systemGray4), lineWidth: 1)
+                            )
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    
+                    Spacer(minLength: 24)
+                }
+                .padding(.vertical, 12)
+            }
+            
+            // 하단 제출 버튼
+            Button {
+                if vm.isFree { vm.dto.price = 0 } else { vm.commitPriceFromText() }
+                vm.createTapped()      // 현재는 print로 확인
+            } label: {
+                Text("모임 만들기")
+                    .font(.system(size: 17, weight: .semibold))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 52)
+                    .background(vm.canSubmit ? Color.black : Color(.systemGray5))
+                    .foregroundStyle(vm.canSubmit ? .white : .secondary)
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+            }
+            .disabled(!vm.canSubmit)
+            .background(Color(.systemBackground))
+        }
+        .background(Color(.systemBackground))
+    }
+}
+
+#Preview {
+    CreateMoimView()
+}

--- a/FlatBread/Features/CreateMoim/Presentation/ViewModel/CreateMoinViewModel.swift
+++ b/FlatBread/Features/CreateMoim/Presentation/ViewModel/CreateMoinViewModel.swift
@@ -1,0 +1,116 @@
+//
+//  CreateMoinViewModel.swift
+//  FlatBread
+//
+//  Created by andev on 11/14/25.
+//
+
+import SwiftUI
+import Combine
+import CoreLocation
+
+@MainActor
+final class CreateMoimViewModel: ObservableObject {
+
+    // 서버 전송용 DTO
+    @Published var dto = PostUploadRequestDTO(
+        category: nil,
+        title: nil,
+        price: 0,
+        content: nil,
+        value1: nil, value2: nil, value3: nil, value4: nil, value5: nil,
+        value6: nil, value7: nil, value8: nil, value9: nil, value10: nil,
+        files: [],
+        longitude: 126.9780,   // 서울 시청 근방
+        latitude: 37.5665
+    )
+
+    // UI 상태
+    @Published var categories: [MoimCategory] = .dummy10
+    @Published var selectedCategory: MoimCategory? = nil
+    @Published var isFree: Bool = true
+    @Published var priceText: String = ""      // 유료일 때만 사용(숫자 문자열)
+
+    let titleLimit = 24
+    let contentLimit = 500
+
+    var titleBinding: Binding<String> {
+        .init(
+            get: { self.dto.title ?? "" },
+            set: { [weak self] in
+                guard let self else { return }
+                let trimmed = String($0.prefix(titleLimit))
+                dto.title = trimmed.isEmpty ? nil : trimmed
+            }
+        )
+    }
+
+    var contentBinding: Binding<String> {
+        .init(
+            get: { self.dto.content ?? "" },
+            set: { [weak self] in
+                guard let self else { return }
+                let trimmed = String($0.prefix(contentLimit))
+                dto.content = trimmed.isEmpty ? nil : trimmed
+            }
+        )
+    }
+
+    var canSubmit: Bool {
+        (dto.title?.isEmpty == false)
+        && (dto.content?.isEmpty == false)
+        && (dto.category?.isEmpty == false)
+        && (dto.price ?? 0) >= 0
+    }
+
+    func selectCategory(_ cat: MoimCategory) {
+        selectedCategory = cat
+        dto.category = cat.name
+    }
+
+    func toggleFree(_ newValue: Bool) {
+        isFree = newValue
+        if newValue {
+            dto.price = 0
+            priceText = ""
+        }
+    }
+
+    func commitPriceFromText() {
+        guard !isFree else {
+            dto.price = 0
+            return
+        }
+        // 숫자만 추출해서 Int로 저장 (원 단위)
+        let digits = priceText.filter(\.isNumber)
+        dto.price = Int(digits) ?? 0
+        priceText = digits.formattedWithWon() // 표시용 포맷
+    }
+
+    func updateCoordinate(_ coord: CLLocationCoordinate2D) {
+        dto.latitude = coord.latitude
+        dto.longitude = coord.longitude
+    }
+
+    // 임시 업로드 액션(동작 확인용)
+    func createTapped() {
+        print("--- CREATE MOIM DTO ---")
+        print("title:", dto.title ?? "nil")
+        print("category:", dto.category ?? "nil")
+        print("price:", dto.price ?? -1)
+        print("lat/lon:", dto.latitude, dto.longitude)
+        print("content:", dto.content ?? "nil")
+        print("-----------------------")
+    }
+}
+
+// MARK: - Helpers
+private extension String {
+    func formattedWithWon() -> String {
+        guard let int = Int(self) else { return self }
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        let s = formatter.string(from: NSNumber(value: int)) ?? "\(int)"
+        return s
+    }
+}

--- a/FlatBread/Features/CreateMoim/Presentation/ViewModel/CreateMoinViewModel.swift
+++ b/FlatBread/Features/CreateMoim/Presentation/ViewModel/CreateMoinViewModel.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 import Combine
 import CoreLocation
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
 
 @MainActor
 final class CreateMoimViewModel: ObservableObject {
@@ -30,6 +33,11 @@ final class CreateMoimViewModel: ObservableObject {
     @Published var selectedCategory: MoimCategory? = nil
     @Published var isFree: Bool = true
     @Published var priceText: String = ""      // 유료일 때만 사용(숫자 문자열)
+    @Published var selectedImageData: Data? = nil
+    @Published var isUploading: Bool = false
+    @Published var uploadErrorMessage: String? = nil
+
+    private let maxUploadFileSizeBytes: Int = 10 * 1024 * 1024 // 10MB
 
     let titleLimit = 24
     let contentLimit = 500
@@ -57,10 +65,9 @@ final class CreateMoimViewModel: ObservableObject {
     }
 
     var canSubmit: Bool {
-        (dto.title?.isEmpty == false)
-        && (dto.content?.isEmpty == false)
-        && (dto.category?.isEmpty == false)
-        && (dto.price ?? 0) >= 0
+        let t = (dto.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let c = (dto.content ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return !t.isEmpty && !c.isEmpty && !(dto.category ?? "").isEmpty && (dto.price ?? 0) >= 0
     }
 
     func selectCategory(_ cat: MoimCategory) {
@@ -91,6 +98,113 @@ final class CreateMoimViewModel: ObservableObject {
         dto.latitude = coord.latitude
         dto.longitude = coord.longitude
     }
+    
+    func setSelectedImage(data: Data?) {
+        selectedImageData = data
+    }
+    
+    // MARK: - 이미지 크기 검증 및 처리 로직
+    private func prepareImageForUpload(_ data: Data, maxBytes: Int = 10 * 1024 * 1024, maxDimension: CGFloat = 2048) -> Data? {
+        // 이미 제한 이하라면 그대로 사용
+        if data.count <= maxBytes { return data }
+
+        // 이미지 디코딩
+        let cfData = data as CFData
+        guard let source = CGImageSourceCreateWithData(cfData, nil) else {
+            print("[ImageValidation] Failed to create CGImageSource from data.")
+            return nil
+        }
+
+        // Helpers
+        func makeThumbnail(maxDim: Int) -> CGImage? {
+            let options: [CFString: Any] = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceThumbnailMaxPixelSize: maxDim,
+                kCGImageSourceCreateThumbnailWithTransform: true
+            ]
+            return CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
+        }
+
+        func jpegData(from cgImage: CGImage, quality: CGFloat) -> Data? {
+            let mutableData = NSMutableData()
+            guard let destination = CGImageDestinationCreateWithData(mutableData, UTType.jpeg.identifier as CFString, 1, nil) else {
+                return nil
+            }
+            let props: [CFString: Any] = [kCGImageDestinationLossyCompressionQuality: quality]
+            CGImageDestinationAddImage(destination, cgImage, props as CFDictionary)
+            guard CGImageDestinationFinalize(destination) else { return nil }
+            return mutableData as Data
+        }
+
+        let initialMax = Int(maxDimension)
+        if let thumb = makeThumbnail(maxDim: initialMax) {
+            // 리사이즈된 이미지에 먼저 높은 품질로 시도
+            if let resizedData = jpegData(from: thumb, quality: 1.0), resizedData.count <= maxBytes {
+                return resizedData
+            }
+
+            // 그 다음 단계적으로 품질 낮춤
+            let qualities: [CGFloat] = [0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.35, 0.3, 0.25, 0.2, 0.18, 0.15, 0.12, 0.1]
+            for q in qualities {
+                if let compressed = jpegData(from: thumb, quality: q), compressed.count <= maxBytes {
+                    return compressed
+                }
+            }
+
+            // 해상도를 점진적으로 더 줄이며 압축 재시도
+            var currentMax = initialMax
+            while currentMax > 800 { // 가장 긴 변이 800px 이하가 되지 않도록
+                currentMax = Int(Double(currentMax) * 0.8)
+                guard let smaller = makeThumbnail(maxDim: currentMax) else { break }
+
+                if let d = jpegData(from: smaller, quality: 0.9), d.count <= maxBytes {
+                    return d
+                }
+                for q in qualities {
+                    if let d = jpegData(from: smaller, quality: q), d.count <= maxBytes {
+                        return d
+                    }
+                }
+            }
+        } else {
+            // Fallback: 썸네일 생성에 실패한 경우, 원본 전체를 압축 시도
+            if let full = CGImageSourceCreateImageAtIndex(source, 0, nil) {
+                if let d = jpegData(from: full, quality: 0.9), d.count <= maxBytes { return d }
+                let qualities: [CGFloat] = [0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.25, 0.2, 0.18, 0.15, 0.12, 0.1]
+                for q in qualities {
+                    if let d = jpegData(from: full, quality: q), d.count <= maxBytes { return d }
+                }
+            }
+        }
+
+        print("[ImageValidation] Unable to reduce image under the max size (\(maxBytes) bytes).")
+        return nil
+    }
+    
+    func submit() async {
+        if isFree { dto.price = 0 } else { commitPriceFromText() }
+
+        if let data = selectedImageData {
+            isUploading = true
+            defer { isUploading = false }
+
+            // 10MB 이하가 되도록 검증: 리사이즈 우선, 필요 시 압축
+            guard let preparedData = prepareImageForUpload(data, maxBytes: maxUploadFileSizeBytes) else {
+                print("[ImageValidation] Image exceeds 10MB even after processing. Aborting upload.")
+                uploadErrorMessage = "이미지 크기가 10MB를 초과합니다. 이미지 크기를 줄인 후 다시 시도해 주세요."
+                return
+            }
+
+            // ---- 실제 업로드 시 교체할 부분 ----
+            let _ = ImageUploadRequestDTO(images: [preparedData])
+            // 서버 업로드 후 반환된 이미지 URL이라고 가정 (더미)
+            let uploadedURL = "https://picsum.photos/seed/flatbread/1200/800"
+            // ----------------------------------
+            dto.files = [uploadedURL]
+        }
+
+        createTapped()
+    }
 
     // 임시 업로드 액션(동작 확인용)
     func createTapped() {
@@ -99,6 +213,7 @@ final class CreateMoimViewModel: ObservableObject {
         print("category:", dto.category ?? "nil")
         print("price:", dto.price ?? -1)
         print("lat/lon:", dto.latitude, dto.longitude)
+        print("files:", dto.files)
         print("content:", dto.content ?? "nil")
         print("-----------------------")
     }


### PR DESCRIPTION

<img width="294" height="586" alt="image" src="https://github.com/user-attachments/assets/36243583-724e-426f-8e34-e56282003de2" />
<img width="292" height="595" alt="image" src="https://github.com/user-attachments/assets/b70a9b3f-fafb-4dad-96ef-d309554ec710" />


## 개요
<!-- 구현한 기능을 간단히 설명해주세요 -->
모임 생성 뷰 구현


## 관련 이슈
#29 

## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- 더미 데이터를 활용해 모임 생성 뷰를 구현
- 좌표 업로드의 경우, 지오코딩이 되어있지 않아 일단 사용자가 직접 지도를 탐색하여 설정하는 방식으로 지정했습니다.
- 사진 업로드 후, await -> 업로드 성공 응답 받고 게시글 업로드 하는 '모임 생성' 플로우 구현
- 이미지 업로드 10MB 용량 제한에 따른 이미지 사이즈 검증 -> 리사이즈 로직 구현
- 실제 네트워크 연동은 미구현 (로그인 로직과 결합해서 추후 구현 예정)

## 체크리스트
- [x] 빌드 성공
- [ ] 테스트 완료
- [ ] 에러 처리 완료
