### PR TITLE
[Chore] `pbxproj`에서 반영되지 않은 `.gitkeep` 삭제 반영

### DIFF
--- a/FlatBread.xcodeproj/project.pbxproj
+++ b/FlatBread.xcodeproj/project.pbxproj
@@ -32,13 +32,11 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Core/DI/.gitkeep,
-				Core/Extensions/.gitkeep,
 				Core/Services/.gitkeep,
 				Core/Utils/.gitkeep,
 				DesignSystem/Components/.gitkeep,
 				DesignSystem/Modifiers/.gitkeep,
 				DesignSystem/Styles/.gitkeep,
-				Features/Chat/.gitkeep,
 				Resources/FlatBread.xctestplan,
 				Resources/Info.plist,
 				Shared/Errors/.gitkeep,


### PR DESCRIPTION
## 개요
<!-- 구현한 기능을 간단히 설명해주세요 -->
`pbxproj`에서 반영되지 않았던 `.gitkeep` 삭제 내용을 `pbxproj` 파일에도 반영하였습니다.

## 관련 이슈
Resolves #36 

## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- `pbxproj`에서 반영되지 않았던 `.gitkeep` 삭제 내용을 `pbxproj` 파일에 반영.
-
-

## 체크리스트
- [x] 빌드 성공
- [ ] 테스트 완료
- [ ] 에러 처리 완료
