### PR TITLE
[feat/HomeViewAPI] 홈 뷰 API 연동 및 화면 라우팅

### DIFF
--- a/FlatBread.xcodeproj/project.pbxproj
+++ b/FlatBread.xcodeproj/project.pbxproj
@@ -435,9 +435,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = FlatBread/FlatBread.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 548W892M42;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FlatBread/Resources/Info.plist;
@@ -457,6 +459,8 @@
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.thegreatflatbread.FlatBread;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Flatbread_Profile_251118;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -477,9 +481,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = FlatBread/FlatBread.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 548W892M42;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FlatBread/Resources/Info.plist;
@@ -499,6 +505,8 @@
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.thegreatflatbread.FlatBread;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Flatbread_Profile_251118;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/FlatBread.xcodeproj/project.pbxproj
+++ b/FlatBread.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 				Resources/Info.plist,
 				Shared/Errors/.gitkeep,
 				Shared/Mappers/.gitkeep,
+				Shared/Models/.gitkeep,
 				Shared/Protocols/.gitkeep,
 			);
 			target = FE6110262EB9D4AD006E4243 /* FlatBread */;
@@ -434,11 +435,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = FlatBread/FlatBread.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 548W892M42;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FlatBread/Resources/Info.plist;
@@ -458,8 +457,6 @@
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.thegreatflatbread.FlatBread;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Flatbread_Profile_251118;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -482,6 +479,7 @@
 				CODE_SIGN_ENTITLEMENTS = FlatBread/FlatBread.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FlatBread/Resources/Info.plist;

--- a/FlatBread.xcodeproj/project.pbxproj
+++ b/FlatBread.xcodeproj/project.pbxproj
@@ -41,7 +41,6 @@
 				Resources/Info.plist,
 				Shared/Errors/.gitkeep,
 				Shared/Mappers/.gitkeep,
-				Shared/Models/.gitkeep,
 				Shared/Protocols/.gitkeep,
 			);
 			target = FE6110262EB9D4AD006E4243 /* FlatBread */;

--- a/FlatBread/App/ContentView.swift
+++ b/FlatBread/App/ContentView.swift
@@ -25,7 +25,6 @@ struct ContentView: View {
             // tabItem modifier를 사용하였음.
             TabView {
                 HomeView()
-                    .ignoresSafeArea()
                     .tabItem {
                         Label("홈", systemImage: "house")
                     }

--- a/FlatBread/App/ContentView.swift
+++ b/FlatBread/App/ContentView.swift
@@ -24,7 +24,7 @@ struct ContentView: View {
             // 그 대체제인 Tab은 iOS 18.0 이상부터 사용 가능하므로
             // tabItem modifier를 사용하였음.
             TabView {
-                HomeView()
+                HomeContainerView()
                     .tabItem {
                         Label("홈", systemImage: "house")
                     }

--- a/FlatBread/App/ContentView.swift
+++ b/FlatBread/App/ContentView.swift
@@ -24,7 +24,7 @@ struct ContentView: View {
             // 그 대체제인 Tab은 iOS 18.0 이상부터 사용 가능하므로
             // tabItem modifier를 사용하였음.
             TabView {
-                Color(.green)
+                HomeView()
                     .ignoresSafeArea()
                     .tabItem {
                         Label("홈", systemImage: "house")

--- a/FlatBread/Configs/secrets.xcconfig.example
+++ b/FlatBread/Configs/secrets.xcconfig.example
@@ -1,4 +1,0 @@
-// Secrets.xcconfig.example
-// 이 파일을 복사해서 Secrets.xcconfig로 만들고 본인의 Team ID를 입력하세요
-
-DEVELOPMENT_TEAM = YOUR_TEAM_ID_HERE

--- a/FlatBread/Features/Auth/LoginViewModel.swift
+++ b/FlatBread/Features/Auth/LoginViewModel.swift
@@ -54,7 +54,6 @@ final class LoginViewModel: NSObject, ObservableObject {
             
             Task {
                 await appleLogin(idToken: idToken)
-                isLoginSucceed = true
             }
             
             
@@ -90,7 +89,10 @@ final class LoginViewModel: NSObject, ObservableObject {
             #if DEBUG
             print("accessToken: \(signInInfo.accessToken!)")
             #endif
+            
+            isLoginSucceed = true
         } catch {
+            print("\(error)")
             alertMessage = error.localizedDescription
             showingAlert = true
         }

--- a/FlatBread/Features/Home/Presentation/Components/BannerCardView.swift
+++ b/FlatBread/Features/Home/Presentation/Components/BannerCardView.swift
@@ -16,12 +16,17 @@ struct BannerCardView: View {
             ZStack(alignment: .bottomLeading) {
 
                 // URL 기반 비동기 이미지 로딩
-                AsyncImage(url: URL(string: item.imageURL)) { phase in
-                    switch phase {
-                    case .empty:
+                RemoteImage(
+                    url: item.imageURL,
+                    displayMode: .thumbnail(CGSize(width: geo.size.width, height: geo.size.height)),
+                    placeholder: {
                         Color(.systemGray5)
-
-                    case .success(let image):
+                            .overlay {
+                                ProgressView()
+                            }
+                    },
+                    imageService: DefaultImageService.shared,
+                    content: { image in
                         image
                             .resizable()
                             .aspectRatio(contentMode: .fill)
@@ -30,19 +35,8 @@ struct BannerCardView: View {
                                 height: geo.size.height
                             )
                             .clipped()
-
-                    case .failure:
-                        Color(.systemGray4)
-                            .overlay {
-                                Image(systemName: "photo")
-                                    .font(.system(size: 32, weight: .regular))
-                                    .foregroundStyle(.white.opacity(0.7))
-                            }
-
-                    @unknown default:
-                        Color(.systemGray5)
                     }
-                }
+                )
 
                 // 아래쪽 그라데이션
                 LinearGradient(
@@ -76,6 +70,7 @@ struct BannerCardView: View {
 #Preview {
     BannerCardView(
         item: .init(
+            id: "preview-post-id",
             imageURL: "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
             title: "모임타이틀모임타이틀\n모이면 최저가에!",
             subtitle: "모임 전용 쿠폰 & 이벤트"

--- a/FlatBread/Features/Home/Presentation/Components/BannerCardView.swift
+++ b/FlatBread/Features/Home/Presentation/Components/BannerCardView.swift
@@ -66,16 +66,3 @@ struct BannerCardView: View {
         .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
     }
 }
-
-#Preview {
-    BannerCardView(
-        item: .init(
-            id: "preview-post-id",
-            imageURL: "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-            title: "모임타이틀모임타이틀\n모이면 최저가에!",
-            subtitle: "모임 전용 쿠폰 & 이벤트"
-        )
-    )
-    .padding()
-    .background(.black.opacity(0.1))
-}

--- a/FlatBread/Features/Home/Presentation/Components/BannerCardView.swift
+++ b/FlatBread/Features/Home/Presentation/Components/BannerCardView.swift
@@ -54,6 +54,7 @@ struct BannerCardView: View {
 
                     Text(item.subtitle)
                         .font(.system(size: 13, weight: .medium))
+                        .lineLimit(3)
                         .opacity(0.8)
                 }
                 .foregroundStyle(.white)
@@ -66,3 +67,4 @@ struct BannerCardView: View {
         .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
     }
 }
+

--- a/FlatBread/Features/Home/Presentation/Components/MoimGroupRowView.swift
+++ b/FlatBread/Features/Home/Presentation/Components/MoimGroupRowView.swift
@@ -17,22 +17,22 @@ struct MoimGroupRowView: View {
             onTap?(item)
         } label: {
             HStack(alignment: .top, spacing: 12) {
-                AsyncImage(url: URL(string: item.imageURL)) { phase in
-                    switch phase {
-                    case .empty: Color(.systemGray5)
-                    case .success(let image):
-                        image.resizable().aspectRatio(contentMode: .fill)
-                    case .failure:
-                        Color(.systemGray4).overlay {
-                            Image(systemName: "photo")
-                                .font(.system(size: 20))
-                                .foregroundStyle(.white.opacity(0.8))
-                        }
-                    @unknown default: Color(.systemGray5)
-                    }
+                RemoteImage(
+                    url: item.imageURL,
+                    displayMode: .thumbnail(CGSize(width: 72, height: 72))
+                ) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
                 }
                 .frame(width: 72, height: 72)
+                .background(Color(uiColor: .systemGray5))
                 .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .overlay(
+                    Group {
+                        EmptyView()
+                    }
+                )
                 
                 VStack(alignment: .leading, spacing: 4) {
                     Text(item.title)
@@ -60,17 +60,4 @@ struct MoimGroupRowView: View {
         .buttonStyle(.plain)
         .contentShape(Rectangle())
     }
-}
-
-#Preview {
-    MoimGroupRowView(
-        item: .init(
-            title: "콤플레이 배드민턴 모임🔥 신입모집🔥",
-            subtitle: "함께 성장하는 2030 배드민턴 모임! 🏸",
-            category: "운동/스포츠",
-            memberCount: 251,
-            imageURL: "https://images.unsplash.com/photo-1518604666860-9ed391f76460?auto=format&fit=crop&w=600&q=80"
-        )
-    )
-    .padding()
 }

--- a/FlatBread/Features/Home/Presentation/Model/BannerItem.swift
+++ b/FlatBread/Features/Home/Presentation/Model/BannerItem.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-// 샘플 모델
 struct BannerItem: Identifiable, Equatable {
     typealias ID = String
     let id: ID

--- a/FlatBread/Features/Home/Presentation/Model/BannerItem.swift
+++ b/FlatBread/Features/Home/Presentation/Model/BannerItem.swift
@@ -9,7 +9,8 @@ import Foundation
 
 // 샘플 모델
 struct BannerItem: Identifiable, Equatable {
-    let id = UUID()
+    typealias ID = String
+    let id: ID
     let imageURL: String
     let title: String
     let subtitle: String

--- a/FlatBread/Features/Home/Presentation/Model/CategoryItem.swift
+++ b/FlatBread/Features/Home/Presentation/Model/CategoryItem.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-// 샘플 모델
 struct CategoryItem: Identifiable, Hashable {
     let id = UUID()
     let title: String

--- a/FlatBread/Features/Home/Presentation/Model/CategoryItem.swift
+++ b/FlatBread/Features/Home/Presentation/Model/CategoryItem.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 // 샘플 모델
-struct CategoryItem: Identifiable, Equatable {
+struct CategoryItem: Identifiable, Hashable {
     let id = UUID()
     let title: String
     let symbol: String

--- a/FlatBread/Features/Home/Presentation/Model/MoimGroupItem.swift
+++ b/FlatBread/Features/Home/Presentation/Model/MoimGroupItem.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 struct MoimGroupItem: Identifiable, Equatable {
-    let id = UUID()
+    typealias ID = String
+    let id: ID
     let title: String
     let subtitle: String
     let category: String

--- a/FlatBread/Features/Home/Presentation/View/CategorySectionCard.swift
+++ b/FlatBread/Features/Home/Presentation/View/CategorySectionCard.swift
@@ -12,9 +12,9 @@ struct CategorySectionCard: View {
     let items: [CategoryItem]
     var onTapCategory: ((CategoryItem) -> Void)?
 
-    /// 5열 고정. 기기 너비에 따라 바꾸려면 count 조절
-    private let columns: [GridItem] =
-        Array(repeating: GridItem(.flexible(), spacing: 6), count: 5)
+    /// 2행 고정 (세로 2줄)
+    private let rows: [GridItem] =
+        Array(repeating: GridItem(.fixed(84), spacing: 10), count: 2)
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -23,16 +23,25 @@ struct CategorySectionCard: View {
                 .foregroundStyle(.primary)
                 .padding(.horizontal, 4)
 
-            LazyVGrid(columns: columns, alignment: .center, spacing: 10) {
-                ForEach(items) { item in
-                    CategoryIconCard(
-                        title: item.title,
-                        systemImage: item.symbol,
-                        tint: item.tint
-                    ) {
-                        onTapCategory?(item)
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHGrid(
+                    rows: rows,
+                    alignment: .center,
+                    spacing: 10
+                ) {
+                    ForEach(items, id: \.self.id) { item in
+                        CategoryIconCard(
+                            title: item.title,
+                            systemImage: item.symbol,
+                            tint: item.tint
+                        ) {
+                            onTapCategory?(item)
+                        }
+                        .frame(width: 90) // 한 칸 너비 고정
                     }
                 }
+                .padding(.horizontal, 4)
+                .padding(.vertical, 4)
             }
         }
         .padding(.horizontal, 12)

--- a/FlatBread/Features/Home/Presentation/View/HomeContainerView.swift
+++ b/FlatBread/Features/Home/Presentation/View/HomeContainerView.swift
@@ -32,7 +32,7 @@ struct HomeContainerView: View {
             .navigationDestination(isPresented: $viewModel.isShowingCategoryDetail) {
                 HomeCategoryDetailView(
                     title: viewModel.selectedCategoryTitle ?? "",
-                    items: viewModel.selectedCategoryGroups.map { $0.title }
+                    items: viewModel.selectedCategoryGroups
                 )
             }
         }

--- a/FlatBread/Features/Home/Presentation/View/HomeContainerView.swift
+++ b/FlatBread/Features/Home/Presentation/View/HomeContainerView.swift
@@ -1,0 +1,36 @@
+//
+//  HomeContainerView.swift
+//  FlatBread
+//
+//  Created by andev on 11/19/25.
+//
+
+import SwiftUI
+
+enum HomeRoute: Hashable {
+    case createMoim
+}
+
+struct HomeContainerView: View {
+    
+    @State private var path = NavigationPath()
+    
+    var body: some View {
+        NavigationStack(path: $path) {
+            HomeView {
+                // 플로팅 버튼 탭 시 네비게이션 경로에 push
+                path.append(HomeRoute.createMoim)
+            }
+            .navigationDestination(for: HomeRoute.self) { route in
+                switch route {
+                case .createMoim:
+                    CreateMoimView()
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    HomeContainerView()
+}

--- a/FlatBread/Features/Home/Presentation/View/HomeContainerView.swift
+++ b/FlatBread/Features/Home/Presentation/View/HomeContainerView.swift
@@ -13,6 +13,7 @@ enum HomeRoute: Hashable {
 
 struct HomeContainerView: View {
     
+    @StateObject private var viewModel = HomeViewModel()
     @State private var path = NavigationPath()
     
     var body: some View {
@@ -21,11 +22,18 @@ struct HomeContainerView: View {
                 // 플로팅 버튼 탭 시 네비게이션 경로에 push
                 path.append(HomeRoute.createMoim)
             }
+            .environmentObject(viewModel)
             .navigationDestination(for: HomeRoute.self) { route in
                 switch route {
                 case .createMoim:
                     CreateMoimView()
                 }
+            }
+            .navigationDestination(isPresented: $viewModel.isShowingCategoryDetail) {
+                HomeCategoryDetailView(
+                    title: viewModel.selectedCategoryTitle ?? "",
+                    items: viewModel.selectedCategoryGroups.map { $0.title }
+                )
             }
         }
     }

--- a/FlatBread/Features/Home/Presentation/View/HomeView.swift
+++ b/FlatBread/Features/Home/Presentation/View/HomeView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct HomeView: View {
     
-    @StateObject private var viewModel = HomeViewModel()
+    @EnvironmentObject var viewModel: HomeViewModel
     
     let onTapCreateMoim: () -> Void // 모임 생성 버튼 탭시
     
@@ -63,3 +63,4 @@ struct HomeView: View {
         .background(Color(.systemBackground))
     }
 }
+

--- a/FlatBread/Features/Home/Presentation/View/HomeView.swift
+++ b/FlatBread/Features/Home/Presentation/View/HomeView.swift
@@ -63,9 +63,3 @@ struct HomeView: View {
         .background(Color(.systemBackground))
     }
 }
-
-#Preview {
-    HomeView {
-        print("Tap create moim")
-    }
-}

--- a/FlatBread/Features/Home/Presentation/View/HomeView.swift
+++ b/FlatBread/Features/Home/Presentation/View/HomeView.swift
@@ -44,6 +44,9 @@ struct HomeView: View {
                     }
                     .padding(.vertical, 4)
                 }
+                .refreshable {
+                    await viewModel.refreshHome()
+                }
             }
             
             Button(action: {

--- a/FlatBread/Features/Home/Presentation/View/HomeView.swift
+++ b/FlatBread/Features/Home/Presentation/View/HomeView.swift
@@ -11,41 +11,61 @@ struct HomeView: View {
     
     @StateObject private var viewModel = HomeViewModel()
     
+    let onTapCreateMoim: () -> Void // 모임 생성 버튼 탭시
+    
     var body: some View {
-        VStack(spacing: 0) {
-            // 최상단 커스텀 헤더
-            HomeTopBarView(
-                title: "FlatBread", // 앱 로고 텍스트
-                onSearchTap: {
-                    // TODO: 검색 화면으로 이동
-                    print("Search tapped")
+        ZStack(alignment: .bottomTrailing) {
+            VStack(spacing: 0) {
+                // 최상단 커스텀 헤더
+                HomeTopBarView(
+                    title: "FlatBread", // 앱 로고 텍스트
+                    onSearchTap: {
+                        // TODO: 검색 화면으로 이동
+                        print("Search tapped")
+                    }
+                )
+                
+                ScrollView {
+                    VStack(spacing: 24) {
+                        BannerCarouselView( // 배너 캐러셀
+                            items: viewModel.banners,
+                            onTapBanner: { viewModel.didTapBanner($0) }
+                        )
+                        
+                        CategorySectionCard( // 카테고리 섹션
+                            items: viewModel.categoryItems,
+                            onTapCategory: { viewModel.didTapCategory($0) }
+                        )
+                        MoimGroupSectionView(
+                            items: viewModel.moimGroups,
+                            onTapRow: { viewModel.didTapMoimGroup($0)
+                            }
+                        )
+                    }
+                    .padding(.vertical, 4)
                 }
-            )
-            
-            ScrollView {
-                VStack(spacing: 24) {
-                    BannerCarouselView( // 배너 캐러셀
-                        items: viewModel.banners,
-                        onTapBanner: { viewModel.didTapBanner($0) }
-                    )
-                    
-                    CategorySectionCard( // 카테고리 섹션
-                        items: viewModel.categoryItems,
-                        onTapCategory: { viewModel.didTapCategory($0) }
-                    )
-                    MoimGroupSectionView(
-                        items: viewModel.moimGroups,
-                        onTapRow: { viewModel.didTapMoimGroup($0)
-                        }
-                    )
-                }
-                .padding(.vertical, 4)
             }
+            
+            Button(action: {
+                onTapCreateMoim()
+            }) {
+                Image(systemName: "plus")
+                    .font(.system(size: 24, weight: .bold))
+                    .foregroundColor(.white)
+                    .frame(width: 56, height: 56)
+                    .background(Color.accentColor)
+                    .clipShape(Circle())
+                    .shadow(radius: 8)
+            }
+            .padding(.trailing, 20)
+            .padding(.bottom, 24)
         }
         .background(Color(.systemBackground))
     }
 }
 
 #Preview {
-    HomeView()
+    HomeView {
+        print("Tap create moim")
+    }
 }

--- a/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -64,16 +64,24 @@ final class HomeViewModel: ObservableObject {
 
     // 카테고리 섹션에 보여줄 데이터
     @Published var categoryItems: [CategoryItem] = [
-        .init(title: "추천 호스트", symbol: "heart.fill", tint: .red),
-        .init(title: "소규모 모임", symbol: "person.2.fill", tint: .yellow),
-        .init(title: "주말 모임", symbol: "calendar.badge.clock", tint: .red),
-        .init(title: "당일 모임", symbol: "alarm.fill", tint: .red),
-        .init(title: "대규모 모임", symbol: "person.3.sequence.fill", tint: .orange),
-        .init(title: "넓적빵 PICK", symbol: "hand.thumbsup.fill", tint: .pink),
-        .init(title: "클래스", symbol: "pencil.and.outline", tint: .teal),
-        .init(title: "파티", symbol: "party.popper.fill", tint: .purple),
-        .init(title: "칼퇴각 모임", symbol: "figure.run", tint: .yellow),
-        .init(title: "선착순 할인", symbol: "ticket.fill", tint: .red)
+        .init(title: "운동/스포츠",    symbol: "sportscourt.fill",        tint: .blue),
+        .init(title: "자기계발",      symbol: "brain.head.profile",      tint: .purple),
+        .init(title: "인문학/책/글",  symbol: "book.closed.fill",        tint: .brown),
+        .init(title: "문화/공연/축제", symbol: "theatermasks.fill",      tint: .pink),
+        .init(title: "공예/만들기",    symbol: "scissors",               tint: .orange),
+        .init(title: "봉사활동",      symbol: "hands.sparkles.fill",     tint: .green),
+        .init(title: "차/바이크",     symbol: "car.fill",                tint: .gray),
+        .init(title: "스포츠관람",    symbol: "sportscourt.circle.fill", tint: .indigo),
+        .init(title: "요리/제조",     symbol: "fork.knife.circle.fill",  tint: .red),
+        .init(title: "외국/언어",     symbol: "globe",                   tint: .teal),
+        .init(title: "아웃도어/여행", symbol: "mountain.2.fill",         tint: .green),
+        .init(title: "업종/직무",     symbol: "briefcase.fill",          tint: .brown),
+        .init(title: "음악/악기",     symbol: "music.mic",               tint: .purple),
+        .init(title: "댄스/무용",     symbol: "figure.dance",            tint: .pink),
+        .init(title: "사교/인맥",     symbol: "person.3.fill",           tint: .orange),
+        .init(title: "사진/영상",     symbol: "camera.fill",             tint: .blue),
+        .init(title: "게임/오락",     symbol: "gamecontroller.fill",     tint: .green),
+        .init(title: "반려동물",      symbol: "pawprint.fill",           tint: .brown)
     ]
 
     // 아이템 탭 액션 (추후 네비게이션/필터링 로직 연결)

--- a/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -12,29 +12,7 @@ final class HomeViewModel: ObservableObject {
     
     private let networkService = NetworkServiceFactory.shared.makeNetworkService()
     
-    @Published var moimGroups: [MoimGroupItem] = [
-        .init(
-            title: "콤플레이 배드민턴 모임🔥 신입모집🔥",
-            subtitle: "함께 성장하는 2030 배드민턴 모임! 🏸",
-            category: "운동/스포츠",
-            memberCount: 251,
-            imageURL: "https://images.unsplash.com/photo-1518604666860-9ed391f76460?auto=format&fit=crop&w=600&q=80"
-        ),
-        .init(
-            title: "1인 창업자 AI/디자인/네트워킹",
-            subtitle: "창업, 디자인, 인공지능(AI) 활용 스터디",
-            category: "자기계발",
-            memberCount: 6,
-            imageURL: "https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=600&q=80"
-        ),
-        .init(
-            title: "데일리 한중 언어 교류 (韓中交流)",
-            subtitle: "📌 한중 언어 교류 모임 안내",
-            category: "외국어/언어",
-            memberCount: 146,
-            imageURL: "https://images.unsplash.com/photo-1496307042754-b4aa456c4a2d?auto=format&fit=crop&w=600&q=80"
-        )
-    ]
+    @Published var moimGroups: [MoimGroupItem] = []
     
     @Published var banners: [BannerItem] = []
     
@@ -62,6 +40,7 @@ final class HomeViewModel: ObservableObject {
     init() {
         Task { [weak self] in
             await self?.fetchBanners()
+            await self?.fetchMoimGroups()
         }
     }
     
@@ -98,6 +77,26 @@ final class HomeViewModel: ObservableObject {
             return BannerItem(id: id, imageURL: imageURL, title: title, subtitle: subtitle)
         }
     }
+    
+    private func mapPostsToMoimGroups(_ dto: PostListResponseDTO) -> [MoimGroupItem] {
+        dto.data.compactMap { post in
+            let id = post.post_id ?? ""
+            let title = post.title ?? ""
+            let subtitle = post.content ?? ""
+            let category = post.category ?? ""
+            let memberCount = post.buyers.count
+            let imageURL = post.files.first ?? ""
+            if id.isEmpty && title.isEmpty && subtitle.isEmpty && imageURL.isEmpty { return nil }
+            return MoimGroupItem(
+                id: id,
+                title: title,
+                subtitle: subtitle,
+                category: category,
+                memberCount: memberCount,
+                imageURL: imageURL
+            )
+        }
+    }
 
     private func fetchBanners() async {
         do {
@@ -113,6 +112,24 @@ final class HomeViewModel: ObservableObject {
         } catch {
             #if DEBUG
             print("[HomeViewModel] Failed to fetch banners: \(error)")
+            #endif
+        }
+    }
+    
+    private func fetchMoimGroups() async {
+        do {
+            let response = try await networkService.request(
+                PostRouter.getPostList(next: "", limit: "50", category: []),
+                responseType: PostListResponseDTO.self,
+                interceptorType: .networkWithToken
+            )
+            let groups = mapPostsToMoimGroups(response)
+            await MainActor.run {
+                self.moimGroups = groups
+            }
+        } catch {
+            #if DEBUG
+            print("[HomeViewModel] Failed to fetch moim groups: \(error)")
             #endif
         }
     }

--- a/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -59,7 +59,6 @@ final class HomeViewModel: ObservableObject {
         print("Tapped banner: \(banner.title)")
     }
 
-    // 아이템 탭 액션 (추후 네비게이션 로직 연결)
     func didTapCategory(_ item: CategoryItem) {
         Task { [weak self] in
             guard let self else { return }

--- a/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -10,6 +10,8 @@ import Combine
 
 final class HomeViewModel: ObservableObject {
     
+    private let networkService = NetworkServiceFactory.shared.makeNetworkService()
+    
     @Published var moimGroups: [MoimGroupItem] = [
         .init(
             title: "콤플레이 배드민턴 모임🔥 신입모집🔥",
@@ -34,35 +36,8 @@ final class HomeViewModel: ObservableObject {
         )
     ]
     
-    func didTapMoimGroup(_ moim: MoimGroupItem) {
-        // TODO: 모임 상세 이동
-        print("Tapped moimGroup: \(moim.title)")
-    }
+    @Published var banners: [BannerItem] = []
     
-    @Published var banners: [BannerItem] = [
-        .init(
-            imageURL: "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-            title: "모임타이틀모임타이틀\n모이면 최저가에!",
-            subtitle: "모임 전용 쿠폰 & 이벤트"
-        ),
-        .init(
-            imageURL: "https://images.unsplash.com/photo-1515879218367-8466d910aaa4?auto=format&fit=crop&w=1200&q=80",
-            title: "모임타이틀모임타이틀모임타이틀",
-            subtitle: "지금 놓치면 1년 기다려야 해요"
-        ),
-        .init(
-            imageURL: "https://images.unsplash.com/photo-1519710164239-da123dc03ef4?auto=format&fit=crop&w=1200&q=80",
-            title: "모임타이틀모임타이틀",
-            subtitle: "담요 · 향초 · 머그컵 만드는 모임"
-        )
-    ]
-
-    func didTapBanner(_ banner: BannerItem) {
-        // TODO: 배너 상세 이동 / 웹뷰 열기 등
-        print("Tapped banner: \(banner.title)")
-    }
-
-    // 카테고리 섹션에 보여줄 데이터
     @Published var categoryItems: [CategoryItem] = [
         .init(title: "운동/스포츠",    symbol: "sportscourt.fill",        tint: .blue),
         .init(title: "자기계발",      symbol: "brain.head.profile",      tint: .purple),
@@ -84,9 +59,62 @@ final class HomeViewModel: ObservableObject {
         .init(title: "반려동물",      symbol: "pawprint.fill",           tint: .brown)
     ]
 
+    init() {
+        Task { [weak self] in
+            await self?.fetchBanners()
+        }
+    }
+    
+    func didTapMoimGroup(_ moim: MoimGroupItem) {
+        // TODO: 모임 상세 이동
+        print("Tapped moimGroup: \(moim.title)")
+    }
+    
+    func didTapBanner(_ banner: BannerItem) {
+        // TODO: 배너 상세 이동 / 웹뷰 열기 등
+        print("Tapped banner: \(banner.title)")
+    }
+
     // 아이템 탭 액션 (추후 네비게이션/필터링 로직 연결)
     func didTapCategory(_ item: CategoryItem) {
         // TODO: 라우팅 / 필터링 / 트래킹 등
         print("Tapped category: \(item.title)")
     }
+    
+    @MainActor
+    private func updateBanners(_ items: [BannerItem]) {
+        self.banners = items
+    }
+
+    private func mapPostsToBanners(_ dto: PostListResponseDTO) -> [BannerItem] {
+        let posts = dto.data
+        return posts.compactMap { post in
+            let id = post.post_id ?? ""
+            let imageURL = post.files.first ?? ""
+            let title = post.title ?? ""
+            let subtitle = post.content ?? ""
+            // Skip if completely empty
+            if id.isEmpty && title.isEmpty && subtitle.isEmpty && imageURL.isEmpty { return nil }
+            return BannerItem(id: id, imageURL: imageURL, title: title, subtitle: subtitle)
+        }
+    }
+
+    private func fetchBanners() async {
+        do {
+            let response = try await networkService.request(
+                PostRouter.getPostList(next: "", limit: "50", category: []),
+                responseType: PostListResponseDTO.self,
+                interceptorType: .networkWithToken
+            )
+            let banners = mapPostsToBanners(response)
+            await MainActor.run {
+                self.banners = banners
+            }
+        } catch {
+            #if DEBUG
+            print("[HomeViewModel] Failed to fetch banners: \(error)")
+            #endif
+        }
+    }
 }
+

--- a/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -16,6 +16,11 @@ final class HomeViewModel: ObservableObject {
     
     @Published var banners: [BannerItem] = []
     
+    // Category detail navigation & data
+    @Published var selectedCategoryTitle: String? = nil
+    @Published var selectedCategoryGroups: [MoimGroupItem] = []
+    @Published var isShowingCategoryDetail: Bool = false
+
     @Published var categoryItems: [CategoryItem] = [
         .init(title: "운동/스포츠",    symbol: "sportscourt.fill",        tint: .blue),
         .init(title: "자기계발",      symbol: "brain.head.profile",      tint: .purple),
@@ -54,10 +59,30 @@ final class HomeViewModel: ObservableObject {
         print("Tapped banner: \(banner.title)")
     }
 
-    // 아이템 탭 액션 (추후 네비게이션/필터링 로직 연결)
+    // 아이템 탭 액션 (추후 네비게이션 로직 연결)
     func didTapCategory(_ item: CategoryItem) {
-        // TODO: 라우팅 / 필터링 / 트래킹 등
-        print("Tapped category: \(item.title)")
+        Task { [weak self] in
+            guard let self else { return }
+            self.selectedCategoryTitle = item.title
+            do {
+                let categories: [String] = [item.title]
+                let response = try await self.networkService.request(
+                    PostRouter.getPostList(next: "", limit: "50", category: categories),
+                    responseType: PostListResponseDTO.self,
+                    interceptorType: .networkWithToken
+                )
+                let groups = self.mapPostsToMoimGroups(response)
+                    .sorted { $0.memberCount > $1.memberCount }
+                await MainActor.run {
+                    self.selectedCategoryGroups = groups
+                    self.isShowingCategoryDetail = true
+                }
+            } catch {
+                #if DEBUG
+                print("[HomeViewModel] Failed to fetch category detail for (\(item.title)): \(error)")
+                #endif
+            }
+        }
     }
     
     @MainActor
@@ -131,6 +156,29 @@ final class HomeViewModel: ObservableObject {
         } catch {
             #if DEBUG
             print("[HomeViewModel] Failed to fetch moim groups: \(error)")
+            #endif
+        }
+    }
+    
+    private func fetchMoimGroups(category: String?) async {
+        do {
+            let categories: [String] = {
+                if let c = category, !c.isEmpty { return [c] }
+                return []
+            }()
+            let response = try await networkService.request(
+                PostRouter.getPostList(next: "", limit: "50", category: categories),
+                responseType: PostListResponseDTO.self,
+                interceptorType: .networkWithToken
+            )
+            let groups = mapPostsToMoimGroups(response)
+                .sorted { $0.memberCount > $1.memberCount }
+            await MainActor.run {
+                self.moimGroups = groups
+            }
+        } catch {
+            #if DEBUG
+            print("[HomeViewModel] Failed to fetch moim groups for category (\(category ?? "")): \(error)")
             #endif
         }
     }

--- a/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -49,6 +49,12 @@ final class HomeViewModel: ObservableObject {
         }
     }
     
+    @MainActor
+    func refreshHome() async {
+        await fetchBanners()
+        await fetchMoimGroups()
+    }
+    
     func didTapMoimGroup(_ moim: MoimGroupItem) {
         // TODO: 모임 상세 이동
         print("Tapped moimGroup: \(moim.title)")

--- a/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -124,6 +124,7 @@ final class HomeViewModel: ObservableObject {
                 interceptorType: .networkWithToken
             )
             let groups = mapPostsToMoimGroups(response)
+                .sorted { $0.memberCount > $1.memberCount } // 멤버 많은 순 정렬
             await MainActor.run {
                 self.moimGroups = groups
             }

--- a/FlatBread/Features/HomeCategoryDetail/Presentation/View/HomeCategoryDetailView.swift
+++ b/FlatBread/Features/HomeCategoryDetail/Presentation/View/HomeCategoryDetailView.swift
@@ -1,18 +1,26 @@
-//
-//  HomeCategoryDetailView.swift
-//  FlatBread
-//
-//  Created by andev on 11/20/25.
-//
-
 import SwiftUI
 
 struct HomeCategoryDetailView: View {
+    var title: String = "카테고리"
+    var items: [String] = [
+        "샘플 아이템 1",
+        "샘플 아이템 2",
+        "샘플 아이템 3"
+    ]
+
     var body: some View {
-        Text("Hello, World!")
+        List(items, id: \.self) { item in
+            Text(item)
+        }
+        .navigationTitle(title)
     }
 }
 
 #Preview {
-    HomeCategoryDetailView()
+    NavigationStack {
+        HomeCategoryDetailView(
+            title: "운동/스포츠",
+            items: ["농구", "축구", "수영"]
+        )
+    }
 }

--- a/FlatBread/Features/HomeCategoryDetail/Presentation/View/HomeCategoryDetailView.swift
+++ b/FlatBread/Features/HomeCategoryDetail/Presentation/View/HomeCategoryDetailView.swift
@@ -1,0 +1,18 @@
+//
+//  HomeCategoryDetailView.swift
+//  FlatBread
+//
+//  Created by andev on 11/20/25.
+//
+
+import SwiftUI
+
+struct HomeCategoryDetailView: View {
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+#Preview {
+    HomeCategoryDetailView()
+}

--- a/FlatBread/Features/HomeCategoryDetail/Presentation/View/HomeCategoryDetailView.swift
+++ b/FlatBread/Features/HomeCategoryDetail/Presentation/View/HomeCategoryDetailView.swift
@@ -2,15 +2,18 @@ import SwiftUI
 
 struct HomeCategoryDetailView: View {
     var title: String = "카테고리"
-    var items: [String] = [
-        "샘플 아이템 1",
-        "샘플 아이템 2",
-        "샘플 아이템 3"
-    ]
+    var items: [MoimGroupItem] = []
+    var onTapRow: ((MoimGroupItem) -> Void)? = nil
 
     var body: some View {
-        List(items, id: \.self) { item in
-            Text(item)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(items) { item in
+                    MoimGroupRowView(item: item, onTap: onTapRow)
+                        .padding(.horizontal, 16)
+                }
+            }
+            .padding(.vertical, 12)
         }
         .navigationTitle(title)
     }
@@ -20,7 +23,7 @@ struct HomeCategoryDetailView: View {
     NavigationStack {
         HomeCategoryDetailView(
             title: "운동/스포츠",
-            items: ["농구", "축구", "수영"]
+            items: HomeViewModel().moimGroups
         )
     }
 }


### PR DESCRIPTION
## 개요
<!-- 구현한 기능을 간단히 설명해주세요 -->
<img width="368" height="790" alt="image" src="https://github.com/user-attachments/assets/8e891c73-0ff6-48b1-a724-2ff8d1275a7b" />
<img width="372" height="785" alt="image" src="https://github.com/user-attachments/assets/d2a43873-f467-4eb1-8938-9db685b24c78" />

홈 뷰에 API를 연동하고 화면 라우팅 로직을 구현

## 관련 이슈
Resolves #30 

## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- "배너" API 연동, "활동이 활발한 모임" API 연동
- 모임 카테고리 UI 변경
- 모임 카테고리 별 fetch API 연동해 카테고리 tap 시 화면 HomeCategoryDetailView로 push 되도록 구현
_HomeCategoryDetailView는 아직 페이지네이션은 구현하지 않았습니다 (추후 구현 예정)_
- 우측 하단 플로팅 버튼 추가, 해당 버튼 tap 시 CreateMoimView 로 push되도록 구현

## 체크리스트
- [x] 빌드 성공
- [x] 테스트 완료
- [ ] 에러 처리 완료
