### PR TITLE
[Feat/OnBoardingView] 온보딩 뷰 구현

### DIFF
--- a/FlatBread/App/ContentView.swift
+++ b/FlatBread/App/ContentView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject private var viewModel = LoginViewModel(tokenStorage: DefaultTokenStorage())
+    @State private var showOnboarding = false
     
     init() {
         let tabBarAppearance = UITabBarAppearance()
@@ -16,6 +17,17 @@ struct ContentView: View {
         
         UITabBar.appearance().standardAppearance = tabBarAppearance
         UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
+    }
+    
+    private func checkOnboardingNeeded() async {
+        do {
+            let response = try await NetworkServiceFactory.shared
+                .makeNetworkService()
+                .request(UserRouter.getMeProfile, responseType: UserProfileResponseDTO.self, interceptorType: .networkWithToken)
+            showOnboarding = (response.info1 == nil)
+        } catch {
+            showOnboarding = true
+        }
     }
     
     var body: some View {
@@ -55,6 +67,16 @@ struct ContentView: View {
                         }
                 }
                 .tint(.black)
+                .task {
+                    await checkOnboardingNeeded()
+                }
+                .fullScreenCover(isPresented: $showOnboarding, onDismiss: {
+                    Task {
+                        await checkOnboardingNeeded()
+                    }
+                }) {
+                    OnBoardingView()
+                }
             } else {
                 LoginView(
                     isLoginSucceed: $viewModel.isLoginSucceed,

--- a/FlatBread/Features/Onboarding/Presentation/VIewModel/OnBoardingViewModel.swift
+++ b/FlatBread/Features/Onboarding/Presentation/VIewModel/OnBoardingViewModel.swift
@@ -14,6 +14,7 @@ import UniformTypeIdentifiers
 
 @MainActor
 final class OnBoardingViewModel: ObservableObject {
+    // 타입
     enum GenderOption: String, CaseIterable, Identifiable {
         case male, female, other
         var id: String { rawValue }
@@ -26,38 +27,45 @@ final class OnBoardingViewModel: ObservableObject {
         }
     }
 
-    // Inputs
+    // 입력 값
     @Published var nick: String = ""
     @Published var phoneNum: String = ""
     @Published var birthDate: Date = Date()
     @Published var profileImageData: Data? = nil
+    @Published var gender: GenderOption = .other
 
-    // Cached processed image data and validity state
+    // 이미지 상태
     @Published var processedImageData: Data? = nil
     @Published var isImageValid: Bool = true
-
-    // Lightweight preview image data for UI rendering
     @Published var previewImageData: Data? = nil
     @Published var isProcessingImage: Bool = false
 
-    @Published var gender: GenderOption = .other
-
-    // State
+    // UI 상태
     @Published var isUploading: Bool = false
     @Published var uploadProgress: Double = 0
     @Published var errorMessage: String? = nil
     @Published var shouldShowOnboarding: Bool = true
 
+    // 작업(Task)
     private var imagePreprocessTask: Task<Void, Never>? = nil
+
+    private static let birthFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+    private static let forbiddenNickCharacters = CharacterSet(charactersIn: ".,?*\\-@+^${}()|[]\\")
+    private static let phoneRegexPattern = "^[0-9]{9,12}$"
 
     var canSubmit: Bool {
         let nickOK = !nick.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        let phoneOK = phoneNum.isEmpty || phoneNum.range(of: "^[0-9]{9,12}$", options: .regularExpression) != nil
+        let phoneOK = phoneNum.isEmpty || phoneNum.range(of: Self.phoneRegexPattern, options: .regularExpression) != nil
         let containsInvalidNick = !validateNick(nick)
         let imageOK = isImageValid
         return nickOK && phoneOK && !containsInvalidNick && !isUploading && imageOK
     }
 
+    // Actions
     func setProfileImage(data: Data?) {
         profileImageData = data
         isProcessingImage = data != nil
@@ -98,8 +106,31 @@ final class OnBoardingViewModel: ObservableObject {
         }
     }
 
-    // MARK: - Private helpers
+    // 검증
+    func validateNick(_ nick: String) -> Bool {
+        let trimmed = nick.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        // Check no whitespace inside
+        if trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) != nil {
+            return false
+        }
+        // Exclude characters: [.,?*\-@+^${}()|\[\]\\]
+        if trimmed.rangeOfCharacter(from: Self.forbiddenNickCharacters) != nil {
+            return false
+        }
+        return true
+    }
 
+    func sanitizedNick(_ nick: String) -> String {
+        nick.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func prepareProfileImageData(_ data: Data?) -> Data? {
+        guard let data = data else { return nil }
+        return preprocessImageData(data)
+    }
+
+    // 이미지 처리 (Nonisolated 헬퍼)
     nonisolated private func decodeCGImage(from data: Data) -> CGImage? {
         let cfData = data as CFData
         guard let source = CGImageSourceCreateWithData(cfData, nil) else { return nil }
@@ -152,30 +183,6 @@ final class OnBoardingViewModel: ObservableObject {
     private func makeThumbnailData(from cgImage: CGImage, maxSide: CGFloat) -> Data? {
         guard let resized = resizedCGImage(cgImage, maxSide: maxSide) else { return nil }
         return jpegData(from: resized, quality: 0.5)
-    }
-
-    func validateNick(_ nick: String) -> Bool {
-        let trimmed = nick.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
-        // Check no whitespace inside
-        if trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) != nil {
-            return false
-        }
-        // Exclude characters: [.,?*\-@+^${}()|\[\]\\]
-        let forbiddenCharacters = CharacterSet(charactersIn: ".,?*\\-@+^${}()|[]\\")
-        if trimmed.rangeOfCharacter(from: forbiddenCharacters) != nil {
-            return false
-        }
-        return true
-    }
-
-    func sanitizedNick(_ nick: String) -> String {
-        nick.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    func prepareProfileImageData(_ data: Data?) -> Data? {
-        guard let data = data else { return nil }
-        return preprocessImageData(data)
     }
 
     nonisolated func preprocessImageData(_ data: Data) -> Data? {
@@ -231,10 +238,9 @@ final class OnBoardingViewModel: ObservableObject {
         return nil
     }
 
+    // DTO / 포맷팅
     private func formattedBirthDay() -> String? {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: birthDate)
+        Self.birthFormatter.string(from: birthDate)
     }
 
     private var dto: UserProfileUpdateDTO {
@@ -252,6 +258,7 @@ final class OnBoardingViewModel: ObservableObject {
         )
     }
 
+    // 네트워킹
     func checkOnboardingNeeded() async {
         let networkService = NetworkServiceFactory.shared.makeNetworkService()
         do {

--- a/FlatBread/Features/Onboarding/Presentation/VIewModel/OnBoardingViewModel.swift
+++ b/FlatBread/Features/Onboarding/Presentation/VIewModel/OnBoardingViewModel.swift
@@ -38,6 +38,7 @@ final class OnBoardingViewModel: ObservableObject {
 
     // Lightweight preview image data for UI rendering
     @Published var previewImageData: Data? = nil
+    @Published var isProcessingImage: Bool = false
 
     @Published var gender: GenderOption = .other
 
@@ -46,6 +47,8 @@ final class OnBoardingViewModel: ObservableObject {
     @Published var uploadProgress: Double = 0
     @Published var errorMessage: String? = nil
     @Published var shouldShowOnboarding: Bool = true
+
+    private var imagePreprocessTask: Task<Void, Never>? = nil
 
     var canSubmit: Bool {
         let nickOK = !nick.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -57,28 +60,40 @@ final class OnBoardingViewModel: ObservableObject {
 
     func setProfileImage(data: Data?) {
         profileImageData = data
+        isProcessingImage = data != nil
 
-        // Set previewImageData immediately with a lightweight thumbnail
+        // Cancel any existing processing task before starting new work
+        imagePreprocessTask?.cancel()
+
         guard let data = data else {
+            isProcessingImage = false
             previewImageData = nil
             processedImageData = nil
             isImageValid = true
             return
         }
 
-        if let cgImage = decodeCGImage(from: data) {
-            previewImageData = makeThumbnailData(from: cgImage, maxSide: 300)
-        } else {
-            previewImageData = nil
-        }
-
-        // Perform preprocessing asynchronously and cache result to avoid blocking UI
-        Task(priority: .background) { [weak self] in
+        imagePreprocessTask = Task(priority: .background) { [weak self] in
             guard let self = self else { return }
-            let preprocessed = self.preprocessImageData(data)
+            defer { Task { @MainActor in self.isProcessingImage = false } }
+            let preview: Data? = autoreleasepool { [weak self] in
+                guard let self = self else { return nil }
+                if let cg = self.decodeCGImage(from: data) {
+                    return self.makeThumbnailData(from: cg, maxSide: 200)
+                }
+                return nil
+            }
+            try? Task.checkCancellation()
+            let preprocessed: Data? = autoreleasepool { [weak self] in
+                guard let self = self else { return nil }
+                return self.preprocessImageData(data)
+            }
+            try? Task.checkCancellation()
             await MainActor.run {
+                self.previewImageData = preview
                 self.processedImageData = preprocessed
                 self.isImageValid = (preprocessed != nil)
+                self.isProcessingImage = false
             }
         }
     }
@@ -136,7 +151,7 @@ final class OnBoardingViewModel: ObservableObject {
 
     private func makeThumbnailData(from cgImage: CGImage, maxSide: CGFloat) -> Data? {
         guard let resized = resizedCGImage(cgImage, maxSide: maxSide) else { return nil }
-        return jpegData(from: resized, quality: 0.6)
+        return jpegData(from: resized, quality: 0.5)
     }
 
     func validateNick(_ nick: String) -> Bool {
@@ -175,8 +190,8 @@ final class OnBoardingViewModel: ObservableObject {
             return data
         }
 
-        // Try resizing with fixed quality 0.8 at various sizes
-        let resizeSteps: [CGFloat] = [1024, 800, 600, 400]
+        // Try resizing with fixed quality 0.8 at various sizes (reduced steps)
+        let resizeSteps: [CGFloat] = [800, 600, 400]
         var bestData: Data? = nil
         var lastResizedImage: CGImage? = image
 
@@ -194,9 +209,9 @@ final class OnBoardingViewModel: ObservableObject {
             }
         }
 
-        // If none met criteria by resizing at quality 0.8, try quality compression on smallest resized or original if no resizing
+        // If none met criteria by resizing at quality 0.8, try quality compression on smallest resized or original if no resizing (reduced qualities)
         if let imageToCompress = lastResizedImage {
-            let qualities: [CGFloat] = [0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1]
+            let qualities: [CGFloat] = [0.6, 0.4, 0.2]
             for quality in qualities {
                 if let compressedData = jpegData(from: imageToCompress, quality: quality) {
                     if compressedData.count <= preferredMaxSize {

--- a/FlatBread/Features/Onboarding/Presentation/VIewModel/OnBoardingViewModel.swift
+++ b/FlatBread/Features/Onboarding/Presentation/VIewModel/OnBoardingViewModel.swift
@@ -86,8 +86,8 @@ final class OnBoardingViewModel: ObservableObject {
             defer { Task { @MainActor in self.isProcessingImage = false } }
             let preview: Data? = autoreleasepool { [weak self] in
                 guard let self = self else { return nil }
-                if let cg = self.decodeCGImage(from: data) {
-                    return self.makeThumbnailData(from: cg, maxSide: 200)
+                if let cg = self.decodeUprightThumbnail(from: data, maxPixel: 200) {
+                    return self.jpegData(from: cg, quality: 0.5)
                 }
                 return nil
             }
@@ -135,6 +135,17 @@ final class OnBoardingViewModel: ObservableObject {
         let cfData = data as CFData
         guard let source = CGImageSourceCreateWithData(cfData, nil) else { return nil }
         return CGImageSourceCreateImageAtIndex(source, 0, nil)
+    }
+
+    nonisolated private func decodeUprightThumbnail(from data: Data, maxPixel: CGFloat) -> CGImage? {
+        let cfData = data as CFData
+        guard let source = CGImageSourceCreateWithData(cfData, nil) else { return nil }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: Int(maxPixel),
+            kCGImageSourceCreateThumbnailWithTransform: true
+        ]
+        return CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
     }
 
     nonisolated private func resizedCGImage(_ image: CGImage, maxSide: CGFloat) -> CGImage? {
@@ -186,7 +197,7 @@ final class OnBoardingViewModel: ObservableObject {
     }
 
     nonisolated func preprocessImageData(_ data: Data) -> Data? {
-        guard let image = decodeCGImage(from: data) else { return nil }
+        guard let image = decodeUprightThumbnail(from: data, maxPixel: 2000) ?? decodeCGImage(from: data) else { return nil }
 
         // Constants
         let maxSize: Int = 200_000 // 200KB
@@ -328,3 +339,4 @@ final class OnBoardingViewModel: ObservableObject {
         }
     }
 }
+

--- a/FlatBread/Features/Onboarding/Presentation/VIewModel/OnBoardingViewModel.swift
+++ b/FlatBread/Features/Onboarding/Presentation/VIewModel/OnBoardingViewModel.swift
@@ -39,11 +39,81 @@ final class OnBoardingViewModel: ObservableObject {
     var canSubmit: Bool {
         let nickOK = !nick.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let phoneOK = phoneNum.isEmpty || phoneNum.range(of: "^[0-9]{9,12}$", options: .regularExpression) != nil
-        return nickOK && phoneOK && !isUploading
+        let containsInvalidNick = !validateNick(nick)
+        let imageOK = profileImageData == nil || prepareProfileImageData(profileImageData) != nil
+        return nickOK && phoneOK && !containsInvalidNick && !isUploading && imageOK
     }
 
     func setProfileImage(data: Data?) {
         profileImageData = data
+    }
+
+    // MARK: - Private helpers
+
+    func validateNick(_ nick: String) -> Bool {
+        let trimmed = nick.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        // Check no whitespace inside
+        if trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) != nil {
+            return false
+        }
+        // Exclude characters: [.,?*\-@+^${}()|\[\]\\]
+        let forbiddenCharacters = CharacterSet(charactersIn: ".,?*\\-@+^${}()|[]\\")
+        if trimmed.rangeOfCharacter(from: forbiddenCharacters) != nil {
+            return false
+        }
+        return true
+    }
+
+    func sanitizedNick(_ nick: String) -> String {
+        nick.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func prepareProfileImageData(_ data: Data?) -> Data? {
+        guard let data = data else { return nil }
+        guard let image = UIImage(data: data) else { return nil }
+
+        // Detect PNG or JPEG by header bytes
+        let isPNG: Bool = {
+            let pngSignature: [UInt8] = [0x89, 0x50, 0x4E, 0x47]
+            guard data.count >= 4 else { return false }
+            let header = [data[0], data[1], data[2], data[3]]
+            return header == pngSignature
+        }()
+        
+        // Constants
+        let maxSize: Int = 200_000 // 200KB
+        let preferredMaxSize: Int = 100_000 // 100KB preferred
+
+        if isPNG {
+            // For PNG: if size <= maxSize, return original
+            if data.count <= maxSize {
+                return data
+            }
+            // Else try JPEG compression instead below
+        }
+
+        // Compress as JPEG with quality steps from 0.8 down to 0.4
+        let qualities: [CGFloat] = [0.8, 0.7, 0.6, 0.5, 0.4]
+        var bestData: Data? = nil
+        for quality in qualities {
+            if let compressedData = image.jpegData(compressionQuality: quality) {
+                if compressedData.count <= preferredMaxSize {
+                    return compressedData // preferred size reached
+                }
+                if compressedData.count <= maxSize {
+                    bestData = compressedData
+                }
+            }
+        }
+
+        // If no compressed data <= maxSize, try returning bestData if any
+        if let bestData = bestData {
+            return bestData
+        }
+
+        // Cannot compress below maxSize
+        return nil
     }
 
     private func formattedBirthDay() -> String? {
@@ -87,10 +157,41 @@ final class OnBoardingViewModel: ObservableObject {
         uploadProgress = 0
         errorMessage = nil
 
+        let cleanNick = sanitizedNick(nick)
+        guard validateNick(cleanNick) else {
+            isUploading = false
+            errorMessage = "닉네임은 공백 없이 입력해야 하며, 특수 문자는 사용할 수 없습니다."
+            return false
+        }
+
+        var processedImageData: Data? = nil
+        if let originalImageData = profileImageData {
+            guard let compressed = prepareProfileImageData(originalImageData) else {
+                isUploading = false
+                errorMessage = "프로필 이미지는 PNG 또는 JPEG 형식이어야 하며 최대 크기는 200KB를 초과할 수 없습니다."
+                return false
+            }
+            processedImageData = compressed
+        }
+
+        // Build DTO with sanitized nick and processed image
+        let requestDTO = UserProfileUpdateDTO(
+            nick: cleanNick.isEmpty ? nil : cleanNick,
+            phoneNum: phoneNum.isEmpty ? nil : phoneNum,
+            birthDay: formattedBirthDay(),
+            profile: processedImageData,
+            gender: gender.rawValue,
+            info1: "true",
+            info2: nil,
+            info3: nil,
+            info4: nil,
+            info5: nil
+        )
+
         let networkService = NetworkServiceFactory.shared.makeNetworkService()
         do {
             _ = try await networkService.upload(
-                MultipartRouter.updateProfile(request: dto),
+                MultipartRouter.updateProfile(request: requestDTO),
                 responseType: UserProfileResponseDTO.self,
                 progress: { [weak self] progress in
                     Task { @MainActor in

--- a/FlatBread/Features/Onboarding/Presentation/VIewModel/OnBoardingViewModel.swift
+++ b/FlatBread/Features/Onboarding/Presentation/VIewModel/OnBoardingViewModel.swift
@@ -1,0 +1,110 @@
+//
+//  OnBoardingViewModel.swift
+//  FlatBread
+//
+//  Created by andev on 11/23/25.
+//
+
+import Foundation
+import SwiftUI
+import Combine
+
+@MainActor
+final class OnBoardingViewModel: ObservableObject {
+    enum GenderOption: String, CaseIterable, Identifiable {
+        case male, female, other
+        var id: String { rawValue }
+        var display: String {
+            switch self {
+            case .male: return "남성"
+            case .female: return "여성"
+            case .other: return "기타"
+            }
+        }
+    }
+
+    // Inputs
+    @Published var nick: String = ""
+    @Published var phoneNum: String = ""
+    @Published var birthDate: Date = Date()
+    @Published var profileImageData: Data? = nil
+    @Published var gender: GenderOption = .other
+
+    // State
+    @Published var isUploading: Bool = false
+    @Published var uploadProgress: Double = 0
+    @Published var errorMessage: String? = nil
+    @Published var shouldShowOnboarding: Bool = true
+
+    var canSubmit: Bool {
+        let nickOK = !nick.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let phoneOK = phoneNum.isEmpty || phoneNum.range(of: "^[0-9]{9,12}$", options: .regularExpression) != nil
+        return nickOK && phoneOK && !isUploading
+    }
+
+    func setProfileImage(data: Data?) {
+        profileImageData = data
+    }
+
+    private func formattedBirthDay() -> String? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: birthDate)
+    }
+
+    private var dto: UserProfileUpdateDTO {
+        UserProfileUpdateDTO(
+            nick: nick.isEmpty ? nil : nick,
+            phoneNum: phoneNum.isEmpty ? nil : phoneNum,
+            birthDay: formattedBirthDay(),
+            profile: profileImageData,
+            gender: gender.rawValue,
+            info1: "true",
+            info2: nil,
+            info3: nil,
+            info4: nil,
+            info5: nil
+        )
+    }
+
+    func checkOnboardingNeeded() async {
+        let networkService = NetworkServiceFactory.shared.makeNetworkService()
+        do {
+            let response = try await networkService.request(
+                UserRouter.getMeProfile,
+                responseType: UserProfileResponseDTO.self,
+                interceptorType: .networkWithToken
+            )
+            shouldShowOnboarding = (response.info1 == nil)
+        } catch {
+            shouldShowOnboarding = true
+        }
+    }
+
+    func submit() async -> Bool {
+        guard canSubmit else { return false }
+        isUploading = true
+        uploadProgress = 0
+        errorMessage = nil
+
+        let networkService = NetworkServiceFactory.shared.makeNetworkService()
+        do {
+            _ = try await networkService.upload(
+                MultipartRouter.updateProfile(request: dto),
+                responseType: UserProfileResponseDTO.self,
+                progress: { [weak self] progress in
+                    Task { @MainActor in
+                        self?.uploadProgress = progress
+                    }
+                }
+            )
+            isUploading = false
+            shouldShowOnboarding = false
+            return true
+        } catch {
+            isUploading = false
+            errorMessage = error.localizedDescription
+            return false
+        }
+    }
+}

--- a/FlatBread/Features/Onboarding/Presentation/VIewModel/OnBoardingViewModel.swift
+++ b/FlatBread/Features/Onboarding/Presentation/VIewModel/OnBoardingViewModel.swift
@@ -8,7 +8,9 @@
 import Foundation
 import SwiftUI
 import Combine
-import UIKit
+import CoreGraphics
+import ImageIO
+import UniformTypeIdentifiers
 
 @MainActor
 final class OnBoardingViewModel: ObservableObject {
@@ -29,6 +31,14 @@ final class OnBoardingViewModel: ObservableObject {
     @Published var phoneNum: String = ""
     @Published var birthDate: Date = Date()
     @Published var profileImageData: Data? = nil
+
+    // Cached processed image data and validity state
+    @Published var processedImageData: Data? = nil
+    @Published var isImageValid: Bool = true
+
+    // Lightweight preview image data for UI rendering
+    @Published var previewImageData: Data? = nil
+
     @Published var gender: GenderOption = .other
 
     // State
@@ -41,15 +51,93 @@ final class OnBoardingViewModel: ObservableObject {
         let nickOK = !nick.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let phoneOK = phoneNum.isEmpty || phoneNum.range(of: "^[0-9]{9,12}$", options: .regularExpression) != nil
         let containsInvalidNick = !validateNick(nick)
-        let imageOK = profileImageData == nil || prepareProfileImageData(profileImageData) != nil
+        let imageOK = isImageValid
         return nickOK && phoneOK && !containsInvalidNick && !isUploading && imageOK
     }
 
     func setProfileImage(data: Data?) {
         profileImageData = data
+
+        // Set previewImageData immediately with a lightweight thumbnail
+        guard let data = data else {
+            previewImageData = nil
+            processedImageData = nil
+            isImageValid = true
+            return
+        }
+
+        if let cgImage = decodeCGImage(from: data) {
+            previewImageData = makeThumbnailData(from: cgImage, maxSide: 300)
+        } else {
+            previewImageData = nil
+        }
+
+        // Perform preprocessing asynchronously and cache result to avoid blocking UI
+        Task(priority: .background) { [weak self] in
+            guard let self = self else { return }
+            let preprocessed = self.preprocessImageData(data)
+            await MainActor.run {
+                self.processedImageData = preprocessed
+                self.isImageValid = (preprocessed != nil)
+            }
+        }
     }
 
     // MARK: - Private helpers
+
+    nonisolated private func decodeCGImage(from data: Data) -> CGImage? {
+        let cfData = data as CFData
+        guard let source = CGImageSourceCreateWithData(cfData, nil) else { return nil }
+        return CGImageSourceCreateImageAtIndex(source, 0, nil)
+    }
+
+    nonisolated private func resizedCGImage(_ image: CGImage, maxSide: CGFloat) -> CGImage? {
+        let width = CGFloat(image.width)
+        let height = CGFloat(image.height)
+        let aspectRatio = width / height
+        var newSize: CGSize
+        if width > height {
+            newSize = CGSize(width: maxSide, height: maxSide / aspectRatio)
+        } else {
+            newSize = CGSize(width: maxSide * aspectRatio, height: maxSide)
+        }
+
+        guard let colorSpace = image.colorSpace else { return nil }
+        guard let context = CGContext(
+            data: nil,
+            width: Int(newSize.width),
+            height: Int(newSize.height),
+            bitsPerComponent: image.bitsPerComponent,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: image.bitmapInfo.rawValue
+        ) else { return nil }
+
+        context.interpolationQuality = .high
+        context.draw(image, in: CGRect(origin: .zero, size: newSize))
+        return context.makeImage()
+    }
+
+    nonisolated private func jpegData(from image: CGImage, quality: CGFloat) -> Data? {
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(data, UTType.jpeg.identifier as CFString, 1, nil) else { return nil }
+        let options = [kCGImageDestinationLossyCompressionQuality: quality] as CFDictionary
+        CGImageDestinationAddImage(destination, image, options)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return data as Data
+    }
+
+    nonisolated private func isPNG(_ data: Data) -> Bool {
+        let pngSignature: [UInt8] = [0x89, 0x50, 0x4E, 0x47]
+        guard data.count >= 4 else { return false }
+        let header = [data[0], data[1], data[2], data[3]]
+        return header == pngSignature
+    }
+
+    private func makeThumbnailData(from cgImage: CGImage, maxSide: CGFloat) -> Data? {
+        guard let resized = resizedCGImage(cgImage, maxSide: maxSide) else { return nil }
+        return jpegData(from: resized, quality: 0.6)
+    }
 
     func validateNick(_ nick: String) -> Bool {
         let trimmed = nick.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -72,71 +160,51 @@ final class OnBoardingViewModel: ObservableObject {
 
     func prepareProfileImageData(_ data: Data?) -> Data? {
         guard let data = data else { return nil }
-        guard let image = UIImage(data: data) else { return nil }
+        return preprocessImageData(data)
+    }
 
-        // Detect PNG or JPEG by header bytes
-        let isPNG: Bool = {
-            let pngSignature: [UInt8] = [0x89, 0x50, 0x4E, 0x47]
-            guard data.count >= 4 else { return false }
-            let header = [data[0], data[1], data[2], data[3]]
-            return header == pngSignature
-        }()
-        
+    nonisolated func preprocessImageData(_ data: Data) -> Data? {
+        guard let image = decodeCGImage(from: data) else { return nil }
+
         // Constants
         let maxSize: Int = 200_000 // 200KB
         let preferredMaxSize: Int = 100_000 // 100KB preferred
 
         // Early return if PNG and already small enough
-        if isPNG && data.count <= maxSize {
+        if isPNG(data) && data.count <= maxSize {
             return data
-        }
-
-        // Helper to resize UIImage maintaining aspect ratio
-        func resizedImage(_ image: UIImage, maxSide: CGFloat) -> UIImage {
-            let size = image.size
-            let aspectRatio = size.width / size.height
-            var newSize: CGSize
-            if size.width > size.height {
-                newSize = CGSize(width: maxSide, height: maxSide / aspectRatio)
-            } else {
-                newSize = CGSize(width: maxSide * aspectRatio, height: maxSide)
-            }
-            let format = UIGraphicsImageRendererFormat.default()
-            format.opaque = false
-            let renderer = UIGraphicsImageRenderer(size: newSize, format: format)
-            return renderer.image { _ in
-                image.draw(in: CGRect(origin: .zero, size: newSize))
-            }
         }
 
         // Try resizing with fixed quality 0.8 at various sizes
         let resizeSteps: [CGFloat] = [1024, 800, 600, 400]
         var bestData: Data? = nil
-        var lastResizedImage = image
+        var lastResizedImage: CGImage? = image
 
         for maxSide in resizeSteps {
-            let resized = resizedImage(image, maxSide: maxSide)
-            lastResizedImage = resized
-            if let compressedData = resized.jpegData(compressionQuality: 0.8) {
-                if compressedData.count <= preferredMaxSize {
-                    return compressedData
-                }
-                if compressedData.count <= maxSize {
-                    bestData = compressedData
+            if let resized = resizedCGImage(image, maxSide: maxSide) {
+                lastResizedImage = resized
+                if let compressedData = jpegData(from: resized, quality: 0.8) {
+                    if compressedData.count <= preferredMaxSize {
+                        return compressedData
+                    }
+                    if compressedData.count <= maxSize {
+                        bestData = compressedData
+                    }
                 }
             }
         }
 
         // If none met criteria by resizing at quality 0.8, try quality compression on smallest resized or original if no resizing
-        let imageToCompress = lastResizedImage
-        let qualities: [CGFloat] = [0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1]
-        for quality in qualities {
-            if let compressedData = imageToCompress.jpegData(compressionQuality: quality) {
-                if compressedData.count <= preferredMaxSize {
-                    return compressedData
-                }
-                if compressedData.count <= maxSize {
-                    bestData = compressedData
+        if let imageToCompress = lastResizedImage {
+            let qualities: [CGFloat] = [0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1]
+            for quality in qualities {
+                if let compressedData = jpegData(from: imageToCompress, quality: quality) {
+                    if compressedData.count <= preferredMaxSize {
+                        return compressedData
+                    }
+                    if compressedData.count <= maxSize {
+                        bestData = compressedData
+                    }
                 }
             }
         }
@@ -196,14 +264,11 @@ final class OnBoardingViewModel: ObservableObject {
             return false
         }
 
-        var processedImageData: Data? = nil
-        if let originalImageData = profileImageData {
-            guard let compressed = prepareProfileImageData(originalImageData) else {
-                isUploading = false
-                errorMessage = "프로필 이미지는 PNG 또는 JPEG 형식이어야 하며 최대 크기는 200KB를 초과할 수 없습니다."
-                return false
-            }
-            processedImageData = compressed
+        let processedImageData = self.processedImageData
+        if profileImageData != nil && processedImageData == nil {
+            isUploading = false
+            errorMessage = "프로필 이미지는 PNG 또는 JPEG 형식이어야 하며 최대 크기는 200KB를 초과할 수 없습니다."
+            return false
         }
 
         // Build DTO with sanitized nick and processed image
@@ -241,4 +306,3 @@ final class OnBoardingViewModel: ObservableObject {
         }
     }
 }
-

--- a/FlatBread/Features/Onboarding/Presentation/VIewModel/OnBoardingViewModel.swift
+++ b/FlatBread/Features/Onboarding/Presentation/VIewModel/OnBoardingViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 import Combine
+import UIKit
 
 @MainActor
 final class OnBoardingViewModel: ObservableObject {
@@ -85,21 +86,40 @@ final class OnBoardingViewModel: ObservableObject {
         let maxSize: Int = 200_000 // 200KB
         let preferredMaxSize: Int = 100_000 // 100KB preferred
 
-        if isPNG {
-            // For PNG: if size <= maxSize, return original
-            if data.count <= maxSize {
-                return data
-            }
-            // Else try JPEG compression instead below
+        // Early return if PNG and already small enough
+        if isPNG && data.count <= maxSize {
+            return data
         }
 
-        // Compress as JPEG with quality steps from 0.8 down to 0.4
-        let qualities: [CGFloat] = [0.8, 0.7, 0.6, 0.5, 0.4]
+        // Helper to resize UIImage maintaining aspect ratio
+        func resizedImage(_ image: UIImage, maxSide: CGFloat) -> UIImage {
+            let size = image.size
+            let aspectRatio = size.width / size.height
+            var newSize: CGSize
+            if size.width > size.height {
+                newSize = CGSize(width: maxSide, height: maxSide / aspectRatio)
+            } else {
+                newSize = CGSize(width: maxSide * aspectRatio, height: maxSide)
+            }
+            let format = UIGraphicsImageRendererFormat.default()
+            format.opaque = false
+            let renderer = UIGraphicsImageRenderer(size: newSize, format: format)
+            return renderer.image { _ in
+                image.draw(in: CGRect(origin: .zero, size: newSize))
+            }
+        }
+
+        // Try resizing with fixed quality 0.8 at various sizes
+        let resizeSteps: [CGFloat] = [1024, 800, 600, 400]
         var bestData: Data? = nil
-        for quality in qualities {
-            if let compressedData = image.jpegData(compressionQuality: quality) {
+        var lastResizedImage = image
+
+        for maxSide in resizeSteps {
+            let resized = resizedImage(image, maxSide: maxSide)
+            lastResizedImage = resized
+            if let compressedData = resized.jpegData(compressionQuality: 0.8) {
                 if compressedData.count <= preferredMaxSize {
-                    return compressedData // preferred size reached
+                    return compressedData
                 }
                 if compressedData.count <= maxSize {
                     bestData = compressedData
@@ -107,12 +127,24 @@ final class OnBoardingViewModel: ObservableObject {
             }
         }
 
-        // If no compressed data <= maxSize, try returning bestData if any
+        // If none met criteria by resizing at quality 0.8, try quality compression on smallest resized or original if no resizing
+        let imageToCompress = lastResizedImage
+        let qualities: [CGFloat] = [0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1]
+        for quality in qualities {
+            if let compressedData = imageToCompress.jpegData(compressionQuality: quality) {
+                if compressedData.count <= preferredMaxSize {
+                    return compressedData
+                }
+                if compressedData.count <= maxSize {
+                    bestData = compressedData
+                }
+            }
+        }
+
         if let bestData = bestData {
             return bestData
         }
 
-        // Cannot compress below maxSize
         return nil
     }
 
@@ -209,3 +241,4 @@ final class OnBoardingViewModel: ObservableObject {
         }
     }
 }
+

--- a/FlatBread/Features/Onboarding/Presentation/View/OnBoardingView.swift
+++ b/FlatBread/Features/Onboarding/Presentation/View/OnBoardingView.swift
@@ -1,0 +1,213 @@
+//
+//  OnBoardingView.swift
+//  FlatBread
+//
+//  Created by andev on 11/23/25.
+//
+
+import SwiftUI
+import PhotosUI
+
+struct OnBoardingView: View {
+    @StateObject private var vm = OnBoardingViewModel()
+    @State private var pickerItem: PhotosPickerItem? = nil
+    @FocusState private var focusedField: Field?
+
+    enum Field { case nick, phone, birth }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("프로필을 완성해요")
+                    .font(.system(size: 28, weight: .bold))
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+
+            if vm.shouldShowOnboarding {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 20) {
+                        // MARK: - 대표 사진
+                        VStack(alignment: .leading, spacing: 10) {
+                            Text("프로필 사진")
+                                .font(.headline)
+
+                            ZStack {
+                                if let data = vm.profileImageData, let uiImage = UIImage(data: data) {
+                                    Image(uiImage: uiImage)
+                                        .resizable()
+                                        .scaledToFill()
+                                        .frame(maxWidth: .infinity)
+                                        .frame(height: 180)
+                                        .clipped()
+                                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                                } else {
+                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                        .stroke(style: StrokeStyle(lineWidth: 1, dash: [6]))
+                                        .foregroundStyle(Color(.systemGray4))
+                                        .frame(height: 180)
+                                        .overlay {
+                                            VStack(spacing: 8) {
+                                                Image(systemName: "person.crop.circle.badge.plus")
+                                                    .font(.system(size: 26, weight: .semibold))
+                                                Text("프로필 이미지를 선택해 주세요")
+                                                    .font(.subheadline)
+                                                    .foregroundStyle(.secondary)
+                                            }
+                                        }
+                                }
+                            }
+
+                            PhotosPicker(selection: $pickerItem, matching: .images, photoLibrary: .shared()) {
+                                Label("사진 선택", systemImage: "photo.fill.on.rectangle.fill")
+                                    .font(.system(size: 15, weight: .semibold))
+                                    .padding(.horizontal, 14)
+                                    .padding(.vertical, 10)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                            .fill(Color(.systemGray6))
+                                    )
+                            }
+                            .onChange(of: pickerItem) { _, newItem in
+                                guard let item = newItem else { vm.setProfileImage(data: nil); return }
+                                Task {
+                                    if let data = try? await item.loadTransferable(type: Data.self) {
+                                        await MainActor.run { vm.setProfileImage(data: data) }
+                                    }
+                                }
+                            }
+                        }
+                        .padding(.horizontal, 16)
+
+                        // MARK: - 닉네임
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("닉네임")
+                                .font(.headline)
+                            TextField("닉네임을 입력해 주세요", text: $vm.nick)
+                                .textInputAutocapitalization(.never)
+                                .disableAutocorrection(true)
+                                .padding(14)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                        .stroke(Color(.systemGray4), lineWidth: 1)
+                                )
+                                .focused($focusedField, equals: .nick)
+                        }
+                        .padding(.horizontal, 16)
+
+                        // MARK: - 연락처
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("연락처")
+                                .font(.headline)
+                            TextField("숫자만 입력 (예: 01012345678)", text: $vm.phoneNum)
+                                .keyboardType(.numberPad)
+                                .padding(14)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                        .stroke(Color(.systemGray4), lineWidth: 1)
+                                )
+                                .focused($focusedField, equals: .phone)
+                        }
+                        .padding(.horizontal, 16)
+
+                        // MARK: - 생년월일
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("생년월일")
+                                .font(.headline)
+                            VStack(spacing: 4) {
+                                DatePicker("", selection: $vm.birthDate, displayedComponents: .date)
+                                    .labelsHidden()
+                                    .padding(.horizontal, 14)
+                                    .frame(height: 52)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                            .stroke(Color(.systemGray4), lineWidth: 1)
+                                    )
+                                Text(vm.birthDate, formatter: {
+                                    let formatter = DateFormatter()
+                                    formatter.dateFormat = "yyyy-MM-dd"
+                                    return formatter
+                                }())
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 14)
+                            }
+                            .focused($focusedField, equals: .birth)
+                        }
+                        .padding(.horizontal, 16)
+
+                        // MARK: - 성별
+                        VStack(alignment: .leading, spacing: 10) {
+                            Text("성별")
+                                .font(.headline)
+                            Picker("성별", selection: $vm.gender) {
+                                ForEach(OnBoardingViewModel.GenderOption.allCases) { option in
+                                    Text(option.display).tag(option)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+                        }
+                        .padding(.horizontal, 16)
+
+                        Spacer(minLength: 24)
+                    }
+                    .padding(.vertical, 12)
+                }
+
+                if vm.isUploading {
+                    HStack(spacing: 8) {
+                        ProgressView(value: vm.uploadProgress)
+                        Text("업로드 중…")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 4)
+                }
+
+                Button {
+                    Task {
+                        let success = await vm.submit()
+                        if success {
+                            // On success, server now has info1 set. Route to Home.
+                        }
+                    }
+                } label: {
+                    Text("완료")
+                        .font(.system(size: 17, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 52)
+                        .background(vm.canSubmit ? Color.black : Color(.systemGray5))
+                        .foregroundStyle(vm.canSubmit ? .white : .secondary)
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                }
+                .disabled(!vm.canSubmit)
+                .background(Color(.systemBackground))
+            } else {
+                // Onboarding not needed, route to Home here
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .onTapGesture { focusedField = nil }
+        .background(Color(.systemBackground))
+        .alert("프로필 업데이트 실패", isPresented: Binding(
+            get: { vm.errorMessage != nil },
+            set: { if !$0 { vm.errorMessage = nil } }
+        )) {
+            Button("확인", role: .cancel) { vm.errorMessage = nil }
+        } message: {
+            Text(vm.errorMessage ?? "오류가 발생했습니다. 다시 시도해 주세요.")
+        }
+        .task {
+            await vm.checkOnboardingNeeded()
+        }
+    }
+}
+
+#Preview {
+    OnBoardingView()
+}

--- a/FlatBread/Features/Onboarding/Presentation/View/OnBoardingView.swift
+++ b/FlatBread/Features/Onboarding/Presentation/View/OnBoardingView.swift
@@ -15,6 +15,22 @@ struct OnBoardingView: View {
 
     enum Field { case nick, phone, birth }
 
+    // Computed helpers
+    private var formattedBirthDate: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: vm.birthDate)
+    }
+
+    private var isNickValid: Bool {
+        vm.validateNick(vm.nick)
+    }
+
+    private var isProfileImageValid: Bool {
+        guard let data = vm.profileImageData else { return true }
+        return vm.prepareProfileImageData(data) != nil
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             HStack {
@@ -77,6 +93,16 @@ struct OnBoardingView: View {
                                     }
                                 }
                             }
+
+                            Text("이미지 형식: jpg, jpeg, png | 최대 200KB (권장 100KB)")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+
+                            if vm.profileImageData != nil && !isProfileImageValid {
+                                Text("이미지 용량이 너무 큽니다. 200KB 이하로 줄여주세요.")
+                                    .font(.footnote)
+                                    .foregroundStyle(.red)
+                            }
                         }
                         .padding(.horizontal, 16)
 
@@ -93,6 +119,15 @@ struct OnBoardingView: View {
                                         .stroke(Color(.systemGray4), lineWidth: 1)
                                 )
                                 .focused($focusedField, equals: .nick)
+
+                            if !isNickValid {
+                                Text("닉네임은 공백 없이 입력해야 하며,\n특수 문자는 사용할 수 없습니다.")
+                                    .font(.footnote)
+                                    .foregroundStyle(.red)
+                            }
+                            Text("사용 불가 문자: . , ? * - @ + ^ $ { } ( ) | [ ] \\")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
                         }
                         .padding(.horizontal, 16)
 
@@ -124,14 +159,10 @@ struct OnBoardingView: View {
                                         RoundedRectangle(cornerRadius: 12, style: .continuous)
                                             .stroke(Color(.systemGray4), lineWidth: 1)
                                     )
-                                Text(vm.birthDate, formatter: {
-                                    let formatter = DateFormatter()
-                                    formatter.dateFormat = "yyyy-MM-dd"
-                                    return formatter
-                                }())
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                                .padding(.horizontal, 14)
+                                Text(formattedBirthDate)
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                                    .padding(.horizontal, 14)
                             }
                             .focused($focusedField, equals: .birth)
                         }
@@ -186,6 +217,22 @@ struct OnBoardingView: View {
                 }
                 .disabled(!vm.canSubmit)
                 .background(Color(.systemBackground))
+
+                if !vm.canSubmit {
+                    if !isNickValid {
+                        Text("닉네임 형식이 올바르지 않습니다.")
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                            .padding(.bottom, 8)
+                            .padding(.horizontal, 16)
+                    } else if vm.profileImageData != nil && !isProfileImageValid {
+                        Text("이미지 용량이 너무 큽니다. 200KB 이하 파일을 선택해 주세요.")
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                            .padding(.bottom, 8)
+                            .padding(.horizontal, 16)
+                    }
+                }
             } else {
                 // Onboarding not needed, route to Home here
                 ProgressView()

--- a/FlatBread/Features/Onboarding/Presentation/View/OnBoardingView.swift
+++ b/FlatBread/Features/Onboarding/Presentation/View/OnBoardingView.swift
@@ -8,6 +8,180 @@
 import SwiftUI
 import PhotosUI
 
+private struct ProfileImageSection: View {
+    @ObservedObject var vm: OnBoardingViewModel
+    @Binding var pickerItem: PhotosPickerItem?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("프로필 사진")
+                .font(.headline)
+
+            ZStack {
+                if let data = vm.previewImageData, let uiImage = UIImage(data: data) {
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 180)
+                        .clipped()
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                } else {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .stroke(style: StrokeStyle(lineWidth: 1, dash: [6]))
+                        .foregroundStyle(Color(.systemGray4))
+                        .frame(height: 180)
+                        .overlay {
+                            VStack(spacing: 8) {
+                                Image(systemName: "person.crop.circle.badge.plus")
+                                    .font(.system(size: 26, weight: .semibold))
+                                Text("프로필 이미지를 선택해 주세요")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                }
+
+                if vm.isProcessingImage {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .fill(Color.black.opacity(0.05))
+                            .frame(height: 180)
+                        ProgressView()
+                    }
+                    .transition(.opacity)
+                }
+            }
+
+            PhotosPicker(selection: $pickerItem, matching: .images, photoLibrary: .shared()) {
+                Label("사진 선택", systemImage: "photo.fill.on.rectangle.fill")
+                    .font(.system(size: 15, weight: .semibold))
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .fill(Color(.systemGray6))
+                    )
+            }
+            .onChange(of: pickerItem) { _, newItem in
+                guard let item = newItem else { vm.setProfileImage(data: nil); return }
+                Task {
+                    if let data = try? await item.loadTransferable(type: Data.self) {
+                        await MainActor.run { vm.setProfileImage(data: data) }
+                    }
+                }
+            }
+
+            Text("이미지 형식: jpg, jpeg, png | 최대 200KB (권장 100KB)")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            if vm.profileImageData != nil && !vm.isImageValid {
+                Text("이미지 용량이 너무 큽니다. 200KB 이하로 줄여주세요.")
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+}
+
+private struct NicknameSection: View {
+    @ObservedObject var vm: OnBoardingViewModel
+    @FocusState var focusedField: OnBoardingView.Field?
+
+    private var isNickValid: Bool { vm.validateNick(vm.nick) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("닉네임")
+                .font(.headline)
+            TextField("닉네임을 입력해 주세요", text: $vm.nick)
+                .textInputAutocapitalization(.never)
+                .disableAutocorrection(true)
+                .padding(14)
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .stroke(Color(.systemGray4), lineWidth: 1)
+                )
+                .focused($focusedField, equals: .nick)
+
+            if !isNickValid {
+                Text("닉네임은 공백 없이 입력해야 하며,\n특수 문자는 사용할 수 없습니다.")
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+            }
+            Text("사용 불가 문자: . , ? * - @ + ^ $ { } ( ) | [ ] \\")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+private struct PhoneSection: View {
+    @ObservedObject var vm: OnBoardingViewModel
+    @FocusState var focusedField: OnBoardingView.Field?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("연락처")
+                .font(.headline)
+            TextField("숫자만 입력 (예: 01012345678)", text: $vm.phoneNum)
+                .keyboardType(.numberPad)
+                .padding(14)
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .stroke(Color(.systemGray4), lineWidth: 1)
+                )
+                .focused($focusedField, equals: .phone)
+        }
+    }
+}
+
+private struct BirthSection: View {
+    @ObservedObject var vm: OnBoardingViewModel
+    @Binding var formattedBirthDate: String
+    @FocusState var focusedField: OnBoardingView.Field?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("생년월일")
+                .font(.headline)
+            VStack(spacing: 4) {
+                DatePicker("", selection: $vm.birthDate, displayedComponents: .date)
+                    .labelsHidden()
+                    .padding(.horizontal, 14)
+                    .frame(height: 52)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .stroke(Color(.systemGray4), lineWidth: 1)
+                    )
+                Text(formattedBirthDate)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 14)
+            }
+            .focused($focusedField, equals: .birth)
+        }
+    }
+}
+
+private struct GenderSection: View {
+    @ObservedObject var vm: OnBoardingViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("성별")
+                .font(.headline)
+            Picker("성별", selection: $vm.gender) {
+                ForEach(OnBoardingViewModel.GenderOption.allCases) { option in
+                    Text(option.display).tag(option)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+}
+
 struct OnBoardingView: View {
     @StateObject private var vm = OnBoardingViewModel()
     @State private var pickerItem: PhotosPickerItem? = nil
@@ -16,19 +190,18 @@ struct OnBoardingView: View {
     enum Field { case nick, phone, birth }
 
     // Computed helpers
-    private var formattedBirthDate: String {
+    private static let birthFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: vm.birthDate)
+        return formatter
+    }()
+
+    private var formattedBirthDate: String {
+        Self.birthFormatter.string(from: vm.birthDate)
     }
 
     private var isNickValid: Bool {
         vm.validateNick(vm.nick)
-    }
-
-    private var isProfileImageValid: Bool {
-        guard let data = vm.profileImageData else { return true }
-        return vm.prepareProfileImageData(data) != nil
     }
 
     var body: some View {
@@ -45,141 +218,24 @@ struct OnBoardingView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 20) {
                         // MARK: - 대표 사진
-                        VStack(alignment: .leading, spacing: 10) {
-                            Text("프로필 사진")
-                                .font(.headline)
-
-                            ZStack {
-                                if let data = vm.previewImageData, let uiImage = UIImage(data: data) {
-                                    Image(uiImage: uiImage)
-                                        .resizable()
-                                        .scaledToFill()
-                                        .frame(maxWidth: .infinity)
-                                        .frame(height: 180)
-                                        .clipped()
-                                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                                } else {
-                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                        .stroke(style: StrokeStyle(lineWidth: 1, dash: [6]))
-                                        .foregroundStyle(Color(.systemGray4))
-                                        .frame(height: 180)
-                                        .overlay {
-                                            VStack(spacing: 8) {
-                                                Image(systemName: "person.crop.circle.badge.plus")
-                                                    .font(.system(size: 26, weight: .semibold))
-                                                Text("프로필 이미지를 선택해 주세요")
-                                                    .font(.subheadline)
-                                                    .foregroundStyle(.secondary)
-                                            }
-                                        }
-                                }
-                            }
-
-                            PhotosPicker(selection: $pickerItem, matching: .images, photoLibrary: .shared()) {
-                                Label("사진 선택", systemImage: "photo.fill.on.rectangle.fill")
-                                    .font(.system(size: 15, weight: .semibold))
-                                    .padding(.horizontal, 14)
-                                    .padding(.vertical, 10)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                            .fill(Color(.systemGray6))
-                                    )
-                            }
-                            .onChange(of: pickerItem) { _, newItem in
-                                guard let item = newItem else { vm.setProfileImage(data: nil); return }
-                                Task {
-                                    if let data = try? await item.loadTransferable(type: Data.self) {
-                                        await MainActor.run { vm.setProfileImage(data: data) }
-                                    }
-                                }
-                            }
-
-                            Text("이미지 형식: jpg, jpeg, png | 최대 200KB (권장 100KB)")
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-
-                            if vm.profileImageData != nil && !vm.isImageValid {
-                                Text("이미지 용량이 너무 큽니다. 200KB 이하로 줄여주세요.")
-                                    .font(.footnote)
-                                    .foregroundStyle(.red)
-                            }
-                        }
-                        .padding(.horizontal, 16)
+                        ProfileImageSection(vm: vm, pickerItem: $pickerItem)
+                            .padding(.horizontal, 16)
 
                         // MARK: - 닉네임
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("닉네임")
-                                .font(.headline)
-                            TextField("닉네임을 입력해 주세요", text: $vm.nick)
-                                .textInputAutocapitalization(.never)
-                                .disableAutocorrection(true)
-                                .padding(14)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                        .stroke(Color(.systemGray4), lineWidth: 1)
-                                )
-                                .focused($focusedField, equals: .nick)
-
-                            if !isNickValid {
-                                Text("닉네임은 공백 없이 입력해야 하며,\n특수 문자는 사용할 수 없습니다.")
-                                    .font(.footnote)
-                                    .foregroundStyle(.red)
-                            }
-                            Text("사용 불가 문자: . , ? * - @ + ^ $ { } ( ) | [ ] \\")
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                        }
-                        .padding(.horizontal, 16)
+                        NicknameSection(vm: vm, focusedField: _focusedField)
+                            .padding(.horizontal, 16)
 
                         // MARK: - 연락처
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("연락처")
-                                .font(.headline)
-                            TextField("숫자만 입력 (예: 01012345678)", text: $vm.phoneNum)
-                                .keyboardType(.numberPad)
-                                .padding(14)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                        .stroke(Color(.systemGray4), lineWidth: 1)
-                                )
-                                .focused($focusedField, equals: .phone)
-                        }
-                        .padding(.horizontal, 16)
+                        PhoneSection(vm: vm, focusedField: _focusedField)
+                            .padding(.horizontal, 16)
 
                         // MARK: - 생년월일
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("생년월일")
-                                .font(.headline)
-                            VStack(spacing: 4) {
-                                DatePicker("", selection: $vm.birthDate, displayedComponents: .date)
-                                    .labelsHidden()
-                                    .padding(.horizontal, 14)
-                                    .frame(height: 52)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                            .stroke(Color(.systemGray4), lineWidth: 1)
-                                    )
-                                Text(formattedBirthDate)
-                                    .font(.footnote)
-                                    .foregroundStyle(.secondary)
-                                    .padding(.horizontal, 14)
-                            }
-                            .focused($focusedField, equals: .birth)
-                        }
-                        .padding(.horizontal, 16)
+                        BirthSection(vm: vm, formattedBirthDate: .constant(formattedBirthDate), focusedField: _focusedField)
+                            .padding(.horizontal, 16)
 
                         // MARK: - 성별
-                        VStack(alignment: .leading, spacing: 10) {
-                            Text("성별")
-                                .font(.headline)
-                            Picker("성별", selection: $vm.gender) {
-                                ForEach(OnBoardingViewModel.GenderOption.allCases) { option in
-                                    Text(option.display).tag(option)
-                                }
-                            }
-                            .pickerStyle(.segmented)
-                        }
-                        .padding(.horizontal, 16)
+                        GenderSection(vm: vm)
+                            .padding(.horizontal, 16)
 
                         Spacer(minLength: 24)
                     }

--- a/FlatBread/Features/Onboarding/Presentation/View/OnBoardingView.swift
+++ b/FlatBread/Features/Onboarding/Presentation/View/OnBoardingView.swift
@@ -8,6 +8,135 @@
 import SwiftUI
 import PhotosUI
 
+struct OnBoardingView: View {
+    @StateObject private var vm = OnBoardingViewModel()
+    @State private var pickerItem: PhotosPickerItem? = nil
+    @FocusState private var focusedField: Field?
+
+    enum Field { case nick, phone, birth }
+
+    // Computed helpers
+    private static let birthFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    private var formattedBirthDate: String {
+        Self.birthFormatter.string(from: vm.birthDate)
+    }
+
+    private var isNickValid: Bool {
+        vm.validateNick(vm.nick)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("프로필을 완성해요")
+                    .font(.system(size: 28, weight: .bold))
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+
+            if vm.shouldShowOnboarding {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 20) {
+                        // MARK: - 대표 사진
+                        ProfileImageSection(vm: vm, pickerItem: $pickerItem)
+                            .padding(.horizontal, 16)
+
+                        // MARK: - 닉네임
+                        NicknameSection(vm: vm, focusedField: _focusedField)
+                            .padding(.horizontal, 16)
+
+                        // MARK: - 연락처
+                        PhoneSection(vm: vm, focusedField: _focusedField)
+                            .padding(.horizontal, 16)
+
+                        // MARK: - 생년월일
+                        BirthSection(vm: vm, formattedBirthDate: .constant(formattedBirthDate), focusedField: _focusedField)
+                            .padding(.horizontal, 16)
+
+                        // MARK: - 성별
+                        GenderSection(vm: vm)
+                            .padding(.horizontal, 16)
+
+                        Spacer(minLength: 24)
+                    }
+                    .padding(.vertical, 12)
+                }
+
+                if vm.isUploading {
+                    HStack(spacing: 8) {
+                        ProgressView(value: vm.uploadProgress)
+                        Text("업로드 중…")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 4)
+                }
+
+                Button {
+                    Task {
+                        let success = await vm.submit()
+                        if success {
+                            // On success, server now has info1 set. Route to Home.
+                        }
+                    }
+                } label: {
+                    Text("완료")
+                        .font(.system(size: 17, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 52)
+                        .background(vm.canSubmit ? Color.black : Color(.systemGray5))
+                        .foregroundStyle(vm.canSubmit ? .white : .secondary)
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                }
+                .disabled(!vm.canSubmit)
+                .background(Color(.systemBackground))
+
+                if !vm.canSubmit {
+                    if !isNickValid {
+                        Text("닉네임 형식이 올바르지 않습니다.")
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                            .padding(.bottom, 8)
+                            .padding(.horizontal, 16)
+                    } else if vm.profileImageData != nil && !vm.isImageValid {
+                        Text("이미지 용량이 너무 큽니다. 200KB 이하 파일을 선택해 주세요.")
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                            .padding(.bottom, 8)
+                            .padding(.horizontal, 16)
+                    }
+                }
+            } else {
+                // Onboarding not needed, route to Home here
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .onTapGesture { focusedField = nil }
+        .background(Color(.systemBackground))
+        .alert("프로필 업데이트 실패", isPresented: Binding(
+            get: { vm.errorMessage != nil },
+            set: { if !$0 { vm.errorMessage = nil } }
+        )) {
+            Button("확인", role: .cancel) { vm.errorMessage = nil }
+        } message: {
+            Text(vm.errorMessage ?? "오류가 발생했습니다. 다시 시도해 주세요.")
+        }
+        .task {
+            await vm.checkOnboardingNeeded()
+        }
+    }
+}
+
 private struct ProfileImageSection: View {
     @ObservedObject var vm: OnBoardingViewModel
     @Binding var pickerItem: PhotosPickerItem?
@@ -178,135 +307,6 @@ private struct GenderSection: View {
                 }
             }
             .pickerStyle(.segmented)
-        }
-    }
-}
-
-struct OnBoardingView: View {
-    @StateObject private var vm = OnBoardingViewModel()
-    @State private var pickerItem: PhotosPickerItem? = nil
-    @FocusState private var focusedField: Field?
-
-    enum Field { case nick, phone, birth }
-
-    // Computed helpers
-    private static let birthFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter
-    }()
-
-    private var formattedBirthDate: String {
-        Self.birthFormatter.string(from: vm.birthDate)
-    }
-
-    private var isNickValid: Bool {
-        vm.validateNick(vm.nick)
-    }
-
-    var body: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Text("프로필을 완성해요")
-                    .font(.system(size: 28, weight: .bold))
-                Spacer()
-            }
-            .padding(.horizontal, 16)
-            .padding(.top, 12)
-
-            if vm.shouldShowOnboarding {
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 20) {
-                        // MARK: - 대표 사진
-                        ProfileImageSection(vm: vm, pickerItem: $pickerItem)
-                            .padding(.horizontal, 16)
-
-                        // MARK: - 닉네임
-                        NicknameSection(vm: vm, focusedField: _focusedField)
-                            .padding(.horizontal, 16)
-
-                        // MARK: - 연락처
-                        PhoneSection(vm: vm, focusedField: _focusedField)
-                            .padding(.horizontal, 16)
-
-                        // MARK: - 생년월일
-                        BirthSection(vm: vm, formattedBirthDate: .constant(formattedBirthDate), focusedField: _focusedField)
-                            .padding(.horizontal, 16)
-
-                        // MARK: - 성별
-                        GenderSection(vm: vm)
-                            .padding(.horizontal, 16)
-
-                        Spacer(minLength: 24)
-                    }
-                    .padding(.vertical, 12)
-                }
-
-                if vm.isUploading {
-                    HStack(spacing: 8) {
-                        ProgressView(value: vm.uploadProgress)
-                        Text("업로드 중…")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
-                    .padding(.horizontal, 16)
-                    .padding(.bottom, 4)
-                }
-
-                Button {
-                    Task {
-                        let success = await vm.submit()
-                        if success {
-                            // On success, server now has info1 set. Route to Home.
-                        }
-                    }
-                } label: {
-                    Text("완료")
-                        .font(.system(size: 17, weight: .semibold))
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 52)
-                        .background(vm.canSubmit ? Color.black : Color(.systemGray5))
-                        .foregroundStyle(vm.canSubmit ? .white : .secondary)
-                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 8)
-                }
-                .disabled(!vm.canSubmit)
-                .background(Color(.systemBackground))
-
-                if !vm.canSubmit {
-                    if !isNickValid {
-                        Text("닉네임 형식이 올바르지 않습니다.")
-                            .font(.footnote)
-                            .foregroundStyle(.red)
-                            .padding(.bottom, 8)
-                            .padding(.horizontal, 16)
-                    } else if vm.profileImageData != nil && !vm.isImageValid {
-                        Text("이미지 용량이 너무 큽니다. 200KB 이하 파일을 선택해 주세요.")
-                            .font(.footnote)
-                            .foregroundStyle(.red)
-                            .padding(.bottom, 8)
-                            .padding(.horizontal, 16)
-                    }
-                }
-            } else {
-                // Onboarding not needed, route to Home here
-                ProgressView()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
-        }
-        .onTapGesture { focusedField = nil }
-        .background(Color(.systemBackground))
-        .alert("프로필 업데이트 실패", isPresented: Binding(
-            get: { vm.errorMessage != nil },
-            set: { if !$0 { vm.errorMessage = nil } }
-        )) {
-            Button("확인", role: .cancel) { vm.errorMessage = nil }
-        } message: {
-            Text(vm.errorMessage ?? "오류가 발생했습니다. 다시 시도해 주세요.")
-        }
-        .task {
-            await vm.checkOnboardingNeeded()
         }
     }
 }

--- a/FlatBread/Features/Onboarding/Presentation/View/OnBoardingView.swift
+++ b/FlatBread/Features/Onboarding/Presentation/View/OnBoardingView.swift
@@ -50,7 +50,7 @@ struct OnBoardingView: View {
                                 .font(.headline)
 
                             ZStack {
-                                if let data = vm.profileImageData, let uiImage = UIImage(data: data) {
+                                if let data = vm.previewImageData, let uiImage = UIImage(data: data) {
                                     Image(uiImage: uiImage)
                                         .resizable()
                                         .scaledToFill()
@@ -98,7 +98,7 @@ struct OnBoardingView: View {
                                 .font(.footnote)
                                 .foregroundStyle(.secondary)
 
-                            if vm.profileImageData != nil && !isProfileImageValid {
+                            if vm.profileImageData != nil && !vm.isImageValid {
                                 Text("이미지 용량이 너무 큽니다. 200KB 이하로 줄여주세요.")
                                     .font(.footnote)
                                     .foregroundStyle(.red)
@@ -225,7 +225,7 @@ struct OnBoardingView: View {
                             .foregroundStyle(.red)
                             .padding(.bottom, 8)
                             .padding(.horizontal, 16)
-                    } else if vm.profileImageData != nil && !isProfileImageValid {
+                    } else if vm.profileImageData != nil && !vm.isImageValid {
                         Text("이미지 용량이 너무 큽니다. 200KB 이하 파일을 선택해 주세요.")
                             .font(.footnote)
                             .foregroundStyle(.red)

--- a/FlatBread/Features/Onboarding/Presentation/View/OnBoardingView.swift
+++ b/FlatBread/Features/Onboarding/Presentation/View/OnBoardingView.swift
@@ -12,6 +12,8 @@ struct OnBoardingView: View {
     @StateObject private var vm = OnBoardingViewModel()
     @State private var pickerItem: PhotosPickerItem? = nil
     @FocusState private var focusedField: Field?
+    @Environment(\.dismiss) private var dismiss
+    @State private var showSuccessAlert: Bool = false
 
     enum Field { case nick, phone, birth }
 
@@ -83,7 +85,7 @@ struct OnBoardingView: View {
                     Task {
                         let success = await vm.submit()
                         if success {
-                            // On success, server now has info1 set. Route to Home.
+                            showSuccessAlert = true
                         }
                     }
                 } label: {
@@ -130,6 +132,13 @@ struct OnBoardingView: View {
             Button("확인", role: .cancel) { vm.errorMessage = nil }
         } message: {
             Text(vm.errorMessage ?? "오류가 발생했습니다. 다시 시도해 주세요.")
+        }
+        .alert("프로필 설정 완료", isPresented: $showSuccessAlert) {
+            Button("확인") {
+                dismiss()
+            }
+        } message: {
+            Text("프로필 설정이 완료되었습니다.")
         }
         .task {
             await vm.checkOnboardingNeeded()


### PR DESCRIPTION
## 개요
<!-- 구현한 기능을 간단히 설명해주세요 -->
<img width="323" height="652" alt="image" src="https://github.com/user-attachments/assets/be2fce01-8239-45bb-85ba-a16056552459" />
<img width="306" height="649" alt="image" src="https://github.com/user-attachments/assets/0ed6926b-556e-447d-b7b5-e2cfe2690464" />

온보딩 뷰 구현

## 관련 이슈
Resolves #65 

## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- 온보딩 뷰 UI 구현
- 온보딩 뷰 API 연동
- 온보딩 플로우 구현
_애플 소셜 로그인 -> 로그인 완료 후 내 프로필 조회 API GET 요청 -> info1 값 null인 경우 온보딩 뷰 라우팅, true인 경우 홈 뷰 라우팅_
- API 스펙에 맞게 닉네임, 이미지 사이즈 검증 로직 구현

## 체크리스트
- [x] 빌드 성공
- [x] 테스트 완료
- [ ] 에러 처리 완료
