### PR TITLE
[Fix/HomeView/filter-refresh] 홈 뷰 버그 수정 및 모임 필터링 로직 추가

### DIFF
--- a/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -134,7 +134,7 @@ final class HomeViewModel: ObservableObject {
             let title = post.title ?? ""
             let subtitle = post.content ?? ""
             let category = post.category ?? ""
-            let memberCount = post.buyers.count
+            let memberCount = (post.buyers.count) + 1
             let imageURL = post.files.first ?? ""
             if id.isEmpty && title.isEmpty && subtitle.isEmpty && imageURL.isEmpty { return nil }
             return MoimGroupItem(

--- a/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -50,8 +50,43 @@ final class HomeViewModel: ObservableObject {
     
     @MainActor
     func refreshHome() async {
-        await fetchBanners()
-        await fetchMoimGroups()
+        async let bannersTask: [BannerItem] = { @Sendable in
+            do {
+                return try await loadBanners()
+            } catch {
+                return []
+            }
+        }()
+        async let groupsTask: [MoimGroupItem] = { @Sendable in
+            do {
+                return try await loadMoimGroups()
+            } catch {
+                return []
+            }
+        }()
+
+        let (banners, groups) = await (bannersTask, groupsTask)
+        self.banners = banners
+        self.moimGroups = groups
+    }
+
+    private func loadBanners() async throws -> [BannerItem] {
+        let response = try await networkService.request(
+            PostRouter.getPostList(next: "", limit: "50", category: []),
+            responseType: PostListResponseDTO.self,
+            interceptorType: .networkWithToken
+        )
+        return mapPostsToBanners(response)
+    }
+
+    private func loadMoimGroups() async throws -> [MoimGroupItem] {
+        let response = try await networkService.request(
+            PostRouter.getPostList(next: "", limit: "50", category: []),
+            responseType: PostListResponseDTO.self,
+            interceptorType: .networkWithToken
+        )
+        return mapPostsToMoimGroups(response)
+            .sorted { $0.memberCount > $1.memberCount }
     }
 
     func didTapCategory(_ item: CategoryItem, _ onMoveToCategory: @escaping () -> Void) {

--- a/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -40,6 +40,8 @@ final class HomeViewModel: ObservableObject {
         .init(title: "게임/오락",     symbol: "gamecontroller.fill",     tint: .green),
         .init(title: "반려동물",      symbol: "pawprint.fill",           tint: .brown)
     ]
+    
+    private var allCategories: [String] { categoryItems.map { $0.title } }
 
     init() {
         Task {
@@ -72,7 +74,7 @@ final class HomeViewModel: ObservableObject {
 
     private func loadBanners() async throws -> [BannerItem] {
         let response = try await networkService.request(
-            PostRouter.getPostList(next: "", limit: "50", category: []),
+            PostRouter.getPostList(next: "", limit: "50", category: allCategories),
             responseType: PostListResponseDTO.self,
             interceptorType: .networkWithToken
         )
@@ -81,7 +83,7 @@ final class HomeViewModel: ObservableObject {
 
     private func loadMoimGroups() async throws -> [MoimGroupItem] {
         let response = try await networkService.request(
-            PostRouter.getPostList(next: "", limit: "50", category: []),
+            PostRouter.getPostList(next: "", limit: "50", category: allCategories),
             responseType: PostListResponseDTO.self,
             interceptorType: .networkWithToken
         )
@@ -154,7 +156,7 @@ final class HomeViewModel: ObservableObject {
     private func fetchBanners() async {
         do {
             let response = try await networkService.request(
-                PostRouter.getPostList(next: "", limit: "50", category: []),
+                PostRouter.getPostList(next: "", limit: "50", category: allCategories),
                 responseType: PostListResponseDTO.self,
                 interceptorType: .networkWithToken
             )
@@ -172,7 +174,7 @@ final class HomeViewModel: ObservableObject {
     private func fetchMoimGroups() async {
         do {
             let response = try await networkService.request(
-                PostRouter.getPostList(next: "", limit: "50", category: []),
+                PostRouter.getPostList(next: "", limit: "50", category: allCategories),
                 responseType: PostListResponseDTO.self,
                 interceptorType: .networkWithToken
             )

--- a/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -74,7 +74,7 @@ final class HomeViewModel: ObservableObject {
 
     private func loadBanners() async throws -> [BannerItem] {
         let response = try await networkService.request(
-            PostRouter.getPostList(next: "", limit: "50", category: allCategories),
+            PostRouter.getPostList(next: "", limit: "10", category: allCategories),
             responseType: PostListResponseDTO.self,
             interceptorType: .networkWithToken
         )
@@ -156,7 +156,7 @@ final class HomeViewModel: ObservableObject {
     private func fetchBanners() async {
         do {
             let response = try await networkService.request(
-                PostRouter.getPostList(next: "", limit: "50", category: allCategories),
+                PostRouter.getPostList(next: "", limit: "10", category: allCategories),
                 responseType: PostListResponseDTO.self,
                 interceptorType: .networkWithToken
             )

--- a/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -114,11 +114,6 @@ final class HomeViewModel: ObservableObject {
             }
         }
     }
-    
-    @MainActor
-    private func updateBanners(_ items: [BannerItem]) {
-        self.banners = items
-    }
 
     private func mapPostsToBanners(_ dto: PostListResponseDTO) -> [BannerItem] {
         let posts = dto.data
@@ -189,28 +184,4 @@ final class HomeViewModel: ObservableObject {
             #endif
         }
     }
-    
-    private func fetchMoimGroups(category: String?) async {
-        do {
-            let categories: [String] = {
-                if let c = category, !c.isEmpty { return [c] }
-                return []
-            }()
-            let response = try await networkService.request(
-                PostRouter.getPostList(next: "", limit: "50", category: categories),
-                responseType: PostListResponseDTO.self,
-                interceptorType: .networkWithToken
-            )
-            let groups = mapPostsToMoimGroups(response)
-                .sorted { $0.memberCount > $1.memberCount }
-            await MainActor.run {
-                self.moimGroups = groups
-            }
-        } catch {
-            #if DEBUG
-            print("[HomeViewModel] Failed to fetch moim groups for category (\(category ?? "")): \(error)")
-            #endif
-        }
-    }
 }
-


### PR DESCRIPTION
## 개요
<!-- 구현한 기능을 간단히 설명해주세요 -->
홈 뷰 버그 수정 및 모임 필터링 로직 추가

## 관련 이슈
Resolves #66 

## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- 카테고리에 모든 카테고리 삽입해 API 요청 -> '모임'만 디스플레이 되도록 로직 추가
- 홈 뷰 리프레시 로직 비동기 함수 배치 처리
_기존 moimGroups fetch가 뷰 렌더링에 의해 cancel되는 이슈 수정_

## 체크리스트
- [x] 빌드 성공
- [x] 테스트 완료
- [ ] 에러 처리 완료
