### PR TITLE
[Feat/my moim] 화면 전환 로직 추가 및 셀 정렬 수정

### DIFF
--- a/FlatBread/Features/Moim/Presentation/Components/MyJoinedMoimsList.swift
+++ b/FlatBread/Features/Moim/Presentation/Components/MyJoinedMoimsList.swift
@@ -12,6 +12,7 @@ struct MyJoinedMoimsList: View {
     let isLoading: Bool
     let hasMoreData: Bool
     let loadMore: () -> Void
+    let onMoimTap: (String) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -27,7 +28,7 @@ struct MyJoinedMoimsList: View {
                                 .frame(height: 80)
                                 .padding(.horizontal, 16)
                                 .onTapGesture {
-                                    print(moim.title ?? "")
+                                    onMoimTap(moim.id)
                                 }
                                 .onAppear {
                                     // 마지막 아이템이 보이면 다음 페이지 로드
@@ -62,6 +63,9 @@ struct MyJoinedMoimsList: View {
         hasMoreData: true,
         loadMore: {
             print("Load more")
+        },
+        onMoimTap: { moimId in
+            print("Moim tapped: \(moimId)")
         }
     )
 }

--- a/FlatBread/Features/Moim/Presentation/Components/RecommendMoimsList.swift
+++ b/FlatBread/Features/Moim/Presentation/Components/RecommendMoimsList.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct RecommendMoimsList: View {
     let moims: [MoimSearchResultUIModel]
+    let onMoimTap: (String) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -20,6 +21,9 @@ struct RecommendMoimsList: View {
                         ForEach(moims) { item in
                             MoimListCell(moim: .constant(item))
                                 .frame(width: geometry.size.width * 0.9, height: 80)
+                                .onTapGesture {
+                                    onMoimTap(item.id)
+                                }
                         }
                     }
                     .padding(.horizontal, 16)
@@ -31,5 +35,10 @@ struct RecommendMoimsList: View {
 }
 
 #Preview {
-    RecommendMoimsList(moims: [])
+    RecommendMoimsList(
+        moims: [],
+        onMoimTap: { moimId in
+            print("Moim tapped: \(moimId)")
+        }
+    )
 }

--- a/FlatBread/Features/Moim/Presentation/View/MyMoimView.swift
+++ b/FlatBread/Features/Moim/Presentation/View/MyMoimView.swift
@@ -9,20 +9,32 @@ import SwiftUI
 
 struct MyMoimView: View {
     @StateObject private var viewModel = MyMoimViewModel()
+    @State private var selectedMoimId: String?
 
     var body: some View {
         NavigationStack {
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
-                    RecommendMoimsList(moims: viewModel.recommendMoims)
+                    RecommendMoimsList(
+                        moims: viewModel.recommendMoims,
+                        onMoimTap: { moimId in
+                            selectedMoimId = moimId
+                        }
+                    )
 
                     MyJoinedMoimsList(
                         myMoims: viewModel.myMoims,
                         isLoading: viewModel.isLoading,
                         hasMoreData: viewModel.hasMoreData,
-                        loadMore: viewModel.loadMore
+                        loadMore: viewModel.loadMore,
+                        onMoimTap: { moimId in
+                            selectedMoimId = moimId
+                        }
                     )
                 }
+            }
+            .navigationDestination(item: $selectedMoimId) { moimId in
+                PostListView(moimId: moimId)
             }
         }
     }
@@ -31,20 +43,32 @@ struct MyMoimView: View {
 // MARK: - Preview
 private struct MyMoimViewPreview: View {
     @StateObject private var viewModel = PreviewMyMoimViewModel()
+    @State private var selectedMoimId: String?
 
     var body: some View {
         NavigationStack {
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
-                    RecommendMoimsList(moims: viewModel.recommendMoims)
+                    RecommendMoimsList(
+                        moims: viewModel.recommendMoims,
+                        onMoimTap: { moimId in
+                            selectedMoimId = moimId
+                        }
+                    )
 
                     MyJoinedMoimsList(
                         myMoims: viewModel.myMoims,
                         isLoading: viewModel.isLoading,
                         hasMoreData: viewModel.hasMoreData,
-                        loadMore: viewModel.loadMore
+                        loadMore: viewModel.loadMore,
+                        onMoimTap: { moimId in
+                            selectedMoimId = moimId
+                        }
                     )
                 }
+            }
+            .navigationDestination(item: $selectedMoimId) { moimId in
+                PostListView(moimId: moimId)
             }
         }
     }

--- a/FlatBread/Shared/ViewComponents/MoimListCell.swift
+++ b/FlatBread/Shared/ViewComponents/MoimListCell.swift
@@ -62,6 +62,7 @@ struct MoimListCell: View {
                 .padding(4)
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 


### PR DESCRIPTION
## 개요
<!-- 구현한 기능을 간단히 설명해주세요 -->
내 모임 셀에서 추천 모임, 가입한 모임 셀을 클릭시 PostListView로 전환됩니다.
정렬되지 않은 셀이 정렬되도록 변경되었습니다.

## 관련 이슈
Resolves #69 

## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- navigationDestination으로 셀 클릭시 moimID를 반환하여 PostListView에 전달하도록 하였습니다.
- MoimListCell에 frame을 추가하여 너비는 infinity, 정렬은 leading으로 되도록 추가하였습니다.

## 체크리스트
- [x] 빌드 성공
- [ ] 테스트 완료
- [ ] 에러 처리 완료
