### PR TITLE
[Feat/PaymentBusinessLogic] 결제 비즈니스 로직 구현

### DIFF
--- a/FlatBread/Features/Home/Presentation/View/BannerCarouselView.swift
+++ b/FlatBread/Features/Home/Presentation/View/BannerCarouselView.swift
@@ -18,38 +18,59 @@ struct BannerCarouselView: View {
     private let itemSpacing: CGFloat = 0
 
     var body: some View {
-        GeometryReader { proxy in
-            let screenWidth = proxy.size.width
-
-            let itemWidth = screenWidth * 0.85
-            let sidePadding = (screenWidth - itemWidth) / 2
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: itemSpacing) {
-                    ForEach(items) { item in
-                        BannerCardView(item: item)
-                            .frame(width: itemWidth)
-                            .id(item.id)
-                            // 스크롤 위치에 따라 크기, 투명도 변환
-                            .scrollTransition(.interactive, axis: .horizontal) { view, phase in
-                                view
-                                    .scaleEffect(phase.isIdentity ? 1.0 : 0.9)
-                                    .opacity(phase.isIdentity ? 1.0 : 0.8)
-                            }
-                            .onTapGesture {
-                                onTapBanner?(item)
-                            }
-                    }
-                }
-                .scrollTargetLayout()
-                // 첫/마지막 카드도 중앙에 올 수 있게, 그리고 양옆이 보이게
-                .padding(.horizontal, sidePadding)
+        let currentIndex: Int = {
+            if let selectedID = selectedBannerID,
+               let index = items.firstIndex(where: { $0.id == selectedID }) {
+                return index + 1
+            } else {
+                return items.isEmpty ? 0 : 1
             }
-            .scrollTargetBehavior(.viewAligned)
-            .scrollPosition(id: $selectedBannerID)
+        }()
+
+        ZStack(alignment: .topTrailing) {
+            GeometryReader { proxy in
+                let screenWidth = proxy.size.width
+
+                let itemWidth = screenWidth * 0.85
+                let sidePadding = (screenWidth - itemWidth) / 2
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: itemSpacing) {
+                        ForEach(items) { item in
+                            BannerCardView(item: item)
+                                .frame(width: itemWidth)
+                                .id(item.id)
+                                // 스크롤 위치에 따라 크기, 투명도 변환
+                                .scrollTransition(.interactive, axis: .horizontal) { view, phase in
+                                    view
+                                        .scaleEffect(phase.isIdentity ? 1.0 : 0.9)
+                                        .opacity(phase.isIdentity ? 1.0 : 0.8)
+                                }
+                                .onTapGesture {
+                                    onTapBanner?(item)
+                                }
+                        }
+                    }
+                    .scrollTargetLayout()
+                    // 첫/마지막 카드도 중앙에 올 수 있게, 그리고 양옆이 보이게
+                    .padding(.horizontal, sidePadding)
+                }
+                .scrollTargetBehavior(.viewAligned)
+                .scrollPosition(id: $selectedBannerID)
+            }
+            .frame(height: 280)
+
+            Text("\(currentIndex) / \(items.count)")
+                .font(.caption).bold()
+                .foregroundColor(.white)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(.black.opacity(0.25), in: Capsule())
+                .padding(.trailing, 44)
+                .padding(.top, 12)
         }
-        .frame(height: 280)
         .padding(.top, 8)
+        .frame(height: 280)
     }
 }
 

--- a/FlatBread/Features/Home/Presentation/View/BannerCarouselView.swift
+++ b/FlatBread/Features/Home/Presentation/View/BannerCarouselView.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 
-import SwiftUI
-
 struct BannerCarouselView: View {
 
     let items: [BannerItem]

--- a/FlatBread/Features/Home/Presentation/View/CategorySectionCard.swift
+++ b/FlatBread/Features/Home/Presentation/View/CategorySectionCard.swift
@@ -18,7 +18,7 @@ struct CategorySectionCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            Text("넓적빵 모임")
+            Text("이런 모임 어때요?")
                 .font(.system(size: 22, weight: .bold))
                 .foregroundStyle(.primary)
                 .padding(.horizontal, 4)

--- a/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -135,7 +135,7 @@ final class HomeViewModel: ObservableObject {
             let subtitle = post.content ?? ""
             let category = post.category ?? ""
             let price = post.price ?? 0
-            let buyersCount = post.buyers.count
+            let buyersCount = Set(post.buyers).count
             let likeV2Count = post.likes2.count
             let likeLegacyCount = post.likes.count
             let freeMemberCount = (likeV2Count > 0 ? likeV2Count : likeLegacyCount) + 1

--- a/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/FlatBread/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -134,7 +134,12 @@ final class HomeViewModel: ObservableObject {
             let title = post.title ?? ""
             let subtitle = post.content ?? ""
             let category = post.category ?? ""
-            let memberCount = (post.buyers.count) + 1
+            let price = post.price ?? 0
+            let buyersCount = post.buyers.count
+            let likeV2Count = post.likes2.count
+            let likeLegacyCount = post.likes.count
+            let freeMemberCount = (likeV2Count > 0 ? likeV2Count : likeLegacyCount) + 1
+            let memberCount = (price <= 0) ? freeMemberCount : (buyersCount + 1)
             let imageURL = post.files.first ?? ""
             if id.isEmpty && title.isEmpty && subtitle.isEmpty && imageURL.isEmpty { return nil }
             return MoimGroupItem(
@@ -185,3 +190,4 @@ final class HomeViewModel: ObservableObject {
         }
     }
 }
+

--- a/FlatBread/Features/Payment/IamportPaymentView.swift
+++ b/FlatBread/Features/Payment/IamportPaymentView.swift
@@ -55,19 +55,25 @@ final class IamportPaymentViewController: UIViewController {
         
         Iamport.shared.payment(viewController: self,
                                userCode: userCode, payment: payment) { [weak self] response in
+            guard let self else { return }
             if let response {
                 print("[IMP] payment callback - success: \(response.success == true), imp_uid: \(response.imp_uid ?? "nil"), merchant_uid: \(response.merchant_uid ?? "nil"), error_msg: \(response.error_msg ?? "nil")")
                 if response.success == true, let imp = response.imp_uid {
+                    // 성공: 서버 검증 완료 후 콜백 및 닫기
                     Task { [weak self] in
-                        await self?.validatePayment(impUID: imp, postID: self?.input.postId ?? "")
+                        guard let self else { return }
+                        await self.validatePayment(impUID: imp, postID: self.input.postId)
+                        self.onCompleted?(response)
+                        self.dismiss(animated: true)
                     }
+                    return
                 }
             } else {
                 print("[IMP] payment callback - response is nil")
             }
-            self?.onCompleted?(response)
-            // 결제 화면 닫기
-            self?.dismiss(animated: true)
+            // 실패/취소: 즉시 콜백 및 닫기
+            self.onCompleted?(response)
+            self.dismiss(animated: true)
         }
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [weak self] in

--- a/FlatBread/Features/Post/Data/PostMapper.swift
+++ b/FlatBread/Features/Post/Data/PostMapper.swift
@@ -154,7 +154,8 @@ struct PostMapper {
             return nil
         }()
 
-        let memberCount = Int(dto.value4 ?? "0") ?? 0
+        let likeV2Count = dto.likes2.count
+        let memberCount = likeV2Count
         let maxMembers = Int(dto.value3 ?? "100") ?? 100
 
         let hashtags = parseHashtags(from: content)
@@ -308,3 +309,4 @@ struct CommentMapper {
         )
     }
 }
+

--- a/FlatBread/Features/Post/Presentation/View/PostListView.swift
+++ b/FlatBread/Features/Post/Presentation/View/PostListView.swift
@@ -231,7 +231,11 @@ struct PostListView: View {
             PaymentSheetView(input: paymentInput!) { response in
                 if response?.success == true {
                     Task {
+                        // 최신 데이터 반영 후 성공 알림
                         await viewModel.loadInitialData()
+                        await MainActor.run {
+                            viewModel.devAlertMessage = "결제 및 가입이 완료되었습니다."
+                        }
                     }
                 }
             }

--- a/FlatBread/Features/Post/Presentation/View/PostListView.swift
+++ b/FlatBread/Features/Post/Presentation/View/PostListView.swift
@@ -75,6 +75,7 @@ struct PostListView: View {
                             moim: moim,
                             isLeader: viewModel.isLeader,
                             isMember: viewModel.isMember,
+                            memberDisplayCount: viewModel.displayedMemberCount,
                             onJoinTap: {
                                 // 1) 유료 + 이미 멤버(= 탈퇴 의도): 결제 시트로 이동하지 않음, 개발용 Alert 표시
                                 if viewModel.isMember, let input = viewModel.makePaymentInputForMoimJoin(), input.price > 0 {
@@ -325,6 +326,7 @@ extension PostListView {
         let moim: TempPostMoimModel
         let isLeader: Bool
         let isMember: Bool
+        let memberDisplayCount: Int
         let onJoinTap: () -> Void
         
         var body: some View {
@@ -377,7 +379,7 @@ extension PostListView {
                                 Image(systemName: "person.2.fill")
                                     .font(.system(size: 12))
                                     .foregroundStyle(.secondary)
-                                Text("\(moim.memberCount + 1)명")
+                                Text("\(memberDisplayCount)명")
                                     .font(.system(size: 14))
                                     .foregroundStyle(.secondary)
                             }

--- a/FlatBread/Features/Post/Presentation/View/PostListView.swift
+++ b/FlatBread/Features/Post/Presentation/View/PostListView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import iamport_ios
 
 extension PostListView {
     enum ActiveSheet: Identifiable {
@@ -227,7 +228,13 @@ struct PostListView: View {
                 }
             }
         )) {
-            PaymentSheetView(input: paymentInput!)
+            PaymentSheetView(input: paymentInput!) { response in
+                if response?.success == true {
+                    Task {
+                        await viewModel.loadInitialData()
+                    }
+                }
+            }
         }
         .confirmationDialog(
             "게시물 옵션",
@@ -671,8 +678,9 @@ extension PostListView {
 
 private struct PaymentSheetView: View {
     let input: IamportPaymentInput
+    var onCompleted: ((IamportResponse?) -> Void)? = nil
     var body: some View {
-        IamportPaymentView(input: input)
+        IamportPaymentView(input: input, onCompleted: onCompleted)
     }
 }
 

--- a/FlatBread/Features/Post/Presentation/View/PostListView.swift
+++ b/FlatBread/Features/Post/Presentation/View/PostListView.swift
@@ -75,14 +75,22 @@ struct PostListView: View {
                             isLeader: viewModel.isLeader,
                             isMember: viewModel.isMember,
                             onJoinTap: {
-                                // 결제 필요 여부 확인
+                                // 1) 유료 + 이미 멤버(= 탈퇴 의도): 결제 시트로 이동하지 않음, 개발용 Alert 표시
+                                if viewModel.isMember, let input = viewModel.makePaymentInputForMoimJoin(), input.price > 0 {
+                                    viewModel.devAlertMessage = "들어올 땐 맘대로지만 나갈 땐 아니란다"
+                                    return
+                                }
+
+                                // 2) 가입 플로우
                                 if let input = viewModel.makePaymentInputForMoimJoin(), input.price > 0 {
+                                    // 유료 + 아직 미가입: 결제 필요 → 시트 오픈
                                     DispatchQueue.main.async {
                                         self.paymentInput = input
                                         // paymentInput 세팅 이후 시트를 올려 순서 보장
                                         self.showPaymentSheet = true
                                     }
                                 } else {
+                                    // 무료: 기존 likeV2 기반 가입/탈퇴 토글
                                     Task {
                                         await viewModel.toggleMoimMembership()
                                     }
@@ -266,6 +274,17 @@ struct PostListView: View {
         }
         .task {
             await viewModel.loadInitialData()
+        }
+        .alert(
+            viewModel.devAlertMessage ?? "",
+            isPresented: Binding(
+                get: { viewModel.devAlertMessage != nil },
+                set: { if !$0 { viewModel.devAlertMessage = nil } }
+            )
+        ) {
+            Button("확인", role: .cancel) {
+                viewModel.devAlertMessage = nil
+            }
         }
     }
     

--- a/FlatBread/Features/Post/Presentation/ViewModel/PostListViewModel.swift
+++ b/FlatBread/Features/Post/Presentation/ViewModel/PostListViewModel.swift
@@ -58,6 +58,17 @@ final class PostListViewModel: ObservableObject {
         posts.compactMap { $0.schedule }
     }
     
+    var displayedMemberCount: Int {
+        guard let moim else { return 0 }
+        if moim.membershipFee > 0 {
+            // Paid: buyers count (+1 for leader)
+            return lastFetchedBuyers.count + 1
+        } else {
+            // Free: likeV2-based memberCount mapped already into moim.memberCount; display +1 for leader
+            return moim.memberCount + 1
+        }
+    }
+    
     var members: [MemberUIModel] = []
     
     var isMember: Bool {
@@ -388,3 +399,4 @@ final class PostListViewModel: ObservableObject {
         }
     }
 }
+

--- a/FlatBread/Features/Post/Presentation/ViewModel/PostListViewModel.swift
+++ b/FlatBread/Features/Post/Presentation/ViewModel/PostListViewModel.swift
@@ -17,6 +17,7 @@ final class PostListViewModel: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var errorMessage: String?
     @Published var currentUserNick: String = ""
+    @Published var devAlertMessage: String?
     
     private let networkService: AsyncNetworkService = NetworkServiceFactory.shared.makeNetworkService()
     private(set) var currentUserId: String = ""
@@ -290,6 +291,12 @@ final class PostListViewModel: ObservableObject {
         guard let moim else { return }
         isLoading = true
         defer { isLoading = false }
+
+        // Paid + already a member: show development alert instead of starting payment/cancel flow
+        if moim.membershipFee > 0, isMember {
+            devAlertMessage = "들어올 땐 맘대로지만 나갈 땐 아니란다"
+            return
+        }
 
         if moim.membershipFee <= 0 {
             let newStatus = !isMember

--- a/FlatBread/Features/Post/Presentation/ViewModel/PostListViewModel.swift
+++ b/FlatBread/Features/Post/Presentation/ViewModel/PostListViewModel.swift
@@ -22,6 +22,7 @@ final class PostListViewModel: ObservableObject {
     private(set) var currentUserId: String = ""
     private(set) var moimId: String
     private var postIdSet: Set<String> = []
+    private var lastFetchedBuyers: Set<String> = []
     
     private var cursors: [PostType: String] = [
         .all: "", .schedule: "",
@@ -60,6 +61,9 @@ final class PostListViewModel: ObservableObject {
     
     var isMember: Bool {
         guard let moim else { return false }
+        if !lastFetchedBuyers.isEmpty {
+            return lastFetchedBuyers.contains(currentUserId)
+        }
         return moim.memberIds.contains(currentUserId)
     }
     
@@ -173,6 +177,24 @@ final class PostListViewModel: ObservableObject {
             
             if let moimModel = PostMapper.toTempMoimModel(from: response) {
                 let fee = response.price ?? moimModel.membershipFee
+
+                // Capture buyers from the latest get post response (buyers likely non-optional)
+                let buyersFromResponse: [String] = response.buyers
+                self.lastFetchedBuyers = Set(buyersFromResponse)
+
+                // Resolve memberIds depending on free vs paid
+                // - Free: use like-based memberIds from moimModel
+                // - Paid: use creator + buyers
+                let resolvedMemberIds: [String]
+                if fee <= 0 {
+                    resolvedMemberIds = moimModel.memberIds
+                } else {
+                    var set = Set<String>()
+                    set.insert(moimModel.creator.id)
+                    for b in buyersFromResponse { set.insert(b) }
+                    resolvedMemberIds = Array(set)
+                }
+
                 let adjusted = TempPostMoimModel(
                     id: moimModel.id,
                     name: moimModel.name,
@@ -185,7 +207,7 @@ final class PostListViewModel: ObservableObject {
                     hashtags: moimModel.hashtags,
                     createdAt: moimModel.createdAt,
                     creator: moimModel.creator,
-                    memberIds: moimModel.memberIds,
+                    memberIds: resolvedMemberIds,
                     membershipFee: fee
                 )
                 moim = adjusted
@@ -268,15 +290,21 @@ final class PostListViewModel: ObservableObject {
         guard let moim else { return }
         isLoading = true
         defer { isLoading = false }
-        let newStatus = !isMember
-        do {
-            _ = try await networkService.request(
-                PostRouter.togglePostLikeV2(postID: moim.id, like_status: newStatus),
-                responseType: LikeResponseDTO.self
-            )
-            _ = await fetchMoimData()
-        } catch {
-            errorMessage = "모임 \(newStatus ? "가입" : "탈퇴")에 실패했습니다."
+
+        if moim.membershipFee <= 0 {
+            let newStatus = !isMember
+            do {
+                _ = try await networkService.request(
+                    PostRouter.togglePostLikeV2(postID: moim.id, like_status: newStatus),
+                    responseType: LikeResponseDTO.self
+                )
+                if let memberIds = await fetchMoimData() {
+                    await fetchLoadMember(memberIds: memberIds)
+                }
+            } catch {
+                errorMessage = "모임 \(newStatus ? "가입" : "탈퇴")에 실패했습니다."
+            }
+            return
         }
     }
     
@@ -353,4 +381,3 @@ final class PostListViewModel: ObservableObject {
         }
     }
 }
-


### PR DESCRIPTION
## 개요
<!-- 구현한 기능을 간단히 설명해주세요 -->
결제 완료 이후 플로우를 구현

## 관련 이슈
Resolves #74 

## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- 유료모임 멤버 가입 로직 구현
- 유료모임 멤버 탈퇴 로직 구현
_buyers 수정은 모임 작성자만 가능하여 탈퇴는 임시 alert만 구현했습니다_
- 결제 완료 시 UI 리프레시 로직 구현
- 홈 뷰 멤버 수 표시 로직 수정, 모임 뷰 멤버 수 표시 로직 수정
++ 홈 뷰 배너 UI 변경 및 카테고리 타이틀 텍스트 수정

## 체크리스트
- [x] 빌드 성공
- [ ] 테스트 완료
- [ ] 에러 처리 완료
