### PR TITLE
[Feature] 숏폼 일시정지, 2배속 기능 구현

### DIFF
--- a/FlatBread/Features/ShortVideo/Presentation/Components/SideLongPressArea.swift
+++ b/FlatBread/Features/ShortVideo/Presentation/Components/SideLongPressArea.swift
@@ -1,0 +1,36 @@
+//
+//  SideLongPressArea.swift
+//  FlatBread
+//
+//  Created by 김민성 on 12/1/25.
+//
+
+import SwiftUI
+
+struct SideLongPressArea: View {
+    @Binding var isPressing: Bool
+    
+    let onPressingChanged: (Bool) -> Void
+    let onTapGesture: () -> Void
+    
+    var body: some View {
+        Color.clear
+            .contentShape(Rectangle())
+            .onLongPressGesture(
+                minimumDuration: 0.3,
+                maximumDistance: 10,
+                perform: {
+                    self.isPressing = true
+                    onPressingChanged(isPressing)
+                },
+                onPressingChanged: { isPressing in
+                    guard !isPressing else { return }
+                    self.isPressing = isPressing
+                    onPressingChanged(isPressing)
+                }
+            )
+            .onTapGesture { _ in // 매개변수 타입: CGPoint
+                onTapGesture()
+            }
+    }
+}

--- a/FlatBread/Features/ShortVideo/Presentation/ShortVideoFeedCell.swift
+++ b/FlatBread/Features/ShortVideo/Presentation/ShortVideoFeedCell.swift
@@ -25,7 +25,7 @@ struct ShortVideoFeedCell: View {
     @State private var moimInfo: MoimSearchResultUIModel?
     @State private var player: AVPlayer?
     @State private var playerLooper: NSObjectProtocol?
-    @State private var isBuffering: Bool = true
+    @State private var isBuffering: Bool = false
     @State private var showCommentSheet: Bool = false
     @State private var showingAlert: Bool = false
     @State private var alertMessage: String = ""
@@ -263,14 +263,18 @@ struct ShortVideoFeedCell: View {
         let player = playerManager.player(for: video)
         self.player = player
         
-        isBuffering = (player.timeControlStatus != .playing)
-        
         player.publisher(for: \.timeControlStatus)
+            .removeDuplicates()
             .receive(on: RunLoop.main)
             .sink { status in
                 switch status {
                 case .waitingToPlayAtSpecifiedRate:
-                    self.isBuffering = true
+                    guard !isBuffering else { return }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                        if player.timeControlStatus == .waitingToPlayAtSpecifiedRate {
+                            self.isBuffering = true
+                        }
+                    }
                 case .playing, .paused:
                     self.isBuffering = false
                 @unknown default:

--- a/FlatBread/Features/ShortVideo/Presentation/ShortVideoFeedCell.swift
+++ b/FlatBread/Features/ShortVideo/Presentation/ShortVideoFeedCell.swift
@@ -17,6 +17,7 @@ struct ShortVideoFeedCell: View {
     @Binding var shortVideo: ShortVideo
     @Binding var currentVideo: ShortVideo?
     @Binding var myProfile: ShortVideoProfile?
+    @Binding var isLongPressing: Bool
     
     // UI 상태 관리 (낙관적 UI용)
     @State private var localIsLiked: Bool = false
@@ -27,6 +28,8 @@ struct ShortVideoFeedCell: View {
     @State private var playerLooper: NSObjectProtocol?
     @State private var isBuffering: Bool = false
     @State private var showCommentSheet: Bool = false
+    @State private var isPaused: Bool = false
+    @State private var isVideoInfoHidden: Bool = false
     @State private var showingAlert: Bool = false
     @State private var alertMessage: String = ""
     @State private var statusObserver: NSKeyValueObservation?
@@ -34,6 +37,7 @@ struct ShortVideoFeedCell: View {
     
     private let playerManager = PlayerManager.shared
     let networkService = NetworkServiceFactory.shared.makeNetworkService()
+    let feedbackGenerator = UIImpactFeedbackGenerator(style: .light)
     
     /// 이 뷰가 지금 화면에 보이고 있는지 여부
     var isVisible: Bool {
@@ -53,18 +57,76 @@ struct ShortVideoFeedCell: View {
                 }
             }
             
+            ZStack {
+                Color.clear
+                    .contentShape(Rectangle())
+                    .allowsHitTesting(!isLongPressing)
+                    .onTapGesture { _ in
+                        togglePlayPause()
+                    }
+                
+                HStack(spacing: 0) {
+                    // 왼쪽 사이드 Long Press
+                    SideLongPressArea(
+                        isPressing: $isLongPressing,
+                        onPressingChanged: { handleSpeedControl(isPressing: $0) },
+                        onTapGesture: { togglePlayPause() }
+                    )
+                    .frame(width: 120)
+                    
+                    Spacer()
+                    
+                    // 오른쪽 사이드 Long Press
+                    SideLongPressArea(
+                        isPressing: $isLongPressing,
+                        onPressingChanged: { handleSpeedControl(isPressing: $0) },
+                        onTapGesture: { togglePlayPause() }
+                    )
+                    .frame(width: 120)
+                }
+                
+                if isPaused {
+                    Image(systemName: isPaused ? "pause.fill" : "play.fill")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 50, height: 50)
+                        .foregroundColor(.white.opacity(0.8))
+                        .padding(20)
+                        .background(.black.opacity(0.4))
+                        .clipShape(Circle())
+                        .transition(.opacity)
+                        .allowsHitTesting(false)
+                }
+            }
+            
+            VStack(spacing: 5) {
+                Image(systemName: "forward.fill")
+                Text("2x Speed")
+                    .font(.system(size: 14))
+                    .bold()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(.black.opacity(0.6))
+            .cornerRadius(20)
+            .foregroundStyle(.white)
+            .position(x: UIScreen.main.bounds.midX, y: 100)
+            .opacity(isLongPressing ? 1.0 : 0.0)
+            
             if isBuffering {
                 ProgressView()
                     .progressViewStyle(CircularProgressViewStyle())
                     .tint(.white)
                     .scaleEffect(1.5)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .allowsHitTesting(false)
             }
             
             LinearGradient(colors: [.clear, .black.opacity(0.9)],
                            startPoint: .init(x: 0.5, y: 0.7),
                            endPoint: .init(x: 0.5, y: 0.9))
                 .allowsHitTesting(false)
+                .opacity(isVideoInfoHidden ? 0.0 : 1.0)
             
             HStack(alignment: .bottom, spacing: 14) {
                 VStack(alignment: .leading, spacing: 10) {
@@ -131,8 +193,10 @@ struct ShortVideoFeedCell: View {
             }
             .padding(.horizontal)
             .padding(.bottom, bottomInset + 20)
+            .opacity(isVideoInfoHidden ? 0.0 : 1.0)
         }
         .onAppear {
+            feedbackGenerator.prepare()
             setupPlayer(with: shortVideo)
             syncLikeState()
             updateVideoInfo()
@@ -151,6 +215,14 @@ struct ShortVideoFeedCell: View {
         .onChange(of: shortVideo.likes) { oldValue, newValue in
             syncLikeState()
         }
+        .onChange(of: isLongPressing, { _, newValue in
+            withAnimation {
+                isVideoInfoHidden = newValue
+            }
+            if newValue {
+                feedbackGenerator.impactOccurred(intensity: 0.5)
+            }
+        })
         .sheet(isPresented: $showCommentSheet) {
             ShortVideoCommentView(videoID: shortVideo.id)
                 .adaptiveCommentSheetStyle
@@ -163,6 +235,24 @@ struct ShortVideoFeedCell: View {
         } message: {
             Text(alertMessage)
         }
+    }
+    
+    private func togglePlayPause() {
+        if player?.timeControlStatus == .playing {
+            player?.pause()
+            isPaused = true
+        } else {
+            player?.play()
+            isPaused = false
+            player?.rate = 1.0
+        }
+    }
+    
+    private func handleSpeedControl(isPressing: Bool) {
+        guard player?.timeControlStatus != .paused else { return }
+        
+        isLongPressing = isPressing
+        player?.rate = isPressing ? 2.0 : 1.0
     }
     
     // MARK: - Like Logic
@@ -263,6 +353,7 @@ struct ShortVideoFeedCell: View {
         let player = playerManager.player(for: video)
         self.player = player
         
+        player.currentItem?.audioTimePitchAlgorithm = .timeDomain
         player.publisher(for: \.timeControlStatus)
             .removeDuplicates()
             .receive(on: RunLoop.main)
@@ -294,6 +385,7 @@ struct ShortVideoFeedCell: View {
         ) { _ in
             player.seek(to: .zero)
             player.play()
+            player.rate = isLongPressing ? 2.0 : 1.0
         }
         
         if isVisible {

--- a/FlatBread/Features/ShortVideo/Presentation/ShortVideoFeedView.swift
+++ b/FlatBread/Features/ShortVideo/Presentation/ShortVideoFeedView.swift
@@ -19,7 +19,8 @@ struct ShortVideoFeedView: View {
                         ShortVideoFeedCell(bottomInset: proxy.safeAreaInsets.bottom,
                                       shortVideo: video,
                                       currentVideo: $viewModel.currentVideo,
-                                      myProfile: $viewModel.myProfile)
+                                      myProfile: $viewModel.myProfile,
+                                           isLongPressing: $viewModel.isLongPressing)
                             .containerRelativeFrame([.horizontal, .vertical])
                             .id(video.wrappedValue)
                     }
@@ -27,6 +28,7 @@ struct ShortVideoFeedView: View {
                 .ignoresSafeArea()
                 .scrollTargetLayout()
             }
+            .scrollDisabled(viewModel.isLongPressing)
             .scrollTargetBehavior(.paging)
             .scrollPosition(id: $viewModel.currentVideo)
             .ignoresSafeArea()

--- a/FlatBread/Features/ShortVideo/Presentation/ViewModel/ShortVideoFeedViewModel.swift
+++ b/FlatBread/Features/ShortVideo/Presentation/ViewModel/ShortVideoFeedViewModel.swift
@@ -15,6 +15,7 @@ final class ShortVideoFeedViewModel: ObservableObject {
     @Published var currentVideo: ShortVideo?
     @Published var shortVideos: [ShortVideo] = []
     @Published var myProfile: ShortVideoProfile?
+    @Published var isLongPressing: Bool = false
     
     private let playerManager = PlayerManager.shared
     private let networkService = NetworkServiceFactory.shared.makeNetworkService()


### PR DESCRIPTION
## 개요
<!-- 구현한 기능을 간단히 설명해주세요 -->
숏폼에 일시정지, 2배속 기능을 구현했습니다.

## 관련 이슈
Resolves #104 

## 작업 내용
<!-- 구현한 내용을 정리해주세요 -->
- 숏폼 화면 일시정지 구현 (화면 탭 시)
- 숏폼 화면 2배속 구현 (양쪽 사이드 Long Press 시)
- 

## 체크리스트
- [x] 빌드 성공
- [ ] 테스트 완료
- [ ] 에러 처리 완료

| <img width="200" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-01 at 18 04 59" src="https://github.com/user-attachments/assets/975f3d4b-f85c-4383-ba6d-64ac7460d448" /> | <img width="200" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-01 at 18 06 27" src="https://github.com/user-attachments/assets/4a167b35-58d5-46f3-8ba9-cb10cb54cfda" /> | <img width="200" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-01 at 18 08 14" src="https://github.com/user-attachments/assets/eb44c116-2e5f-453e-9c1f-51a9a0b29ed7" /> | <img width="200" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-01 at 18 05 49" src="https://github.com/user-attachments/assets/2d73554c-3524-4cd9-a41a-c06bae1b363a" /> |
|:---:|:---:|:---:|:---:| 



